### PR TITLE
Remove "Cannot find application for window" logspam

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -302,8 +302,7 @@ const Caffeine = new Lang.Class({
                     this._mayInhibit(display, window, true);
                     return false;
                 }));
-            } else
-                log('Cannot find application for window');
+            }
             return;
         }
         let app_id = app.get_id();


### PR DESCRIPTION
The "Cannot find application for window" message appears quite frequently in JS LOG output, indicating that this is a normal occurrence rather than an error state. Further, the message provides no actionable information, and therefore serves no purpose. This change causes caffeine to silently ignore the condition when encountered, instead of logging about it.
