### PR TITLE
Add 3.13 and 3.14 as supported GNOME Shell versions

### DIFF
--- a/caffeine@patapon.info/metadata.json
+++ b/caffeine@patapon.info/metadata.json
@@ -1,5 +1,5 @@
 {
-"shell-version": ["3.10", "3.11", "3.12"],
+"shell-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
 "uuid": "caffeine@patapon.info",
 "name": "Caffeine",
 "description": "Disable the screensaver and auto suspend",


### PR DESCRIPTION
I've tested 3.14 and it seems to work. We can just assume that
3.13 is compatible.
