### PR TITLE
Fix the update-locale.sh script

### DIFF
--- a/update-locale.sh
+++ b/update-locale.sh
@@ -4,6 +4,7 @@ cd caffeine@patapon.info
 
 pot=gnome-shell-extension-caffeine.pot
 
+touch $pot
 xgettext -j *.js -o $pot
 
 for locale_lang in locale/*; do

--- a/update-locale.sh
+++ b/update-locale.sh
@@ -6,6 +6,7 @@ pot=gnome-shell-extension-caffeine.pot
 
 touch $pot
 xgettext -j *.js -o $pot
+xgettext -j schemas/*.xml -o $pot
 
 for locale_lang in locale/*; do
     po=$locale_lang/LC_MESSAGES/gnome-shell-extension-caffeine.po


### PR DESCRIPTION
This branch fixes two related issues with the update-locale.sh script:

* it doesn't work in a clean git checkout, because xgettext -j requires the output pot file to exist already
* the GSettings schema isn't translated