### PR TITLE
Mark as compatible with GNOME Shell 3.22 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Fill the cup to inhibit auto suspend and screensaver.
 
-This extension supports gnome-shell 3.4 to 3.20.
+This extension supports gnome-shell 3.4 to 3.22.
 
 Use the gnome-shell-before-3.10 branch for gnome shell 3.4, 3.6 and 3.8.
 

--- a/caffeine@patapon.info/metadata.json
+++ b/caffeine@patapon.info/metadata.json
@@ -1,5 +1,5 @@
 {
-"shell-version": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.16", "3.18", "3.20"],
+"shell-version": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.16", "3.18", "3.20", "3.22"],
 "uuid": "caffeine@patapon.info",
 "name": "Caffeine",
 "settings-schema": "org.gnome.shell.extensions.caffeine",


### PR DESCRIPTION
Extension works just fine with Gnome 3.22
fixes #71 