### PR TITLE
Initial version of code compatible with Gnome Shell 3.24 (mozjs38)

### DIFF
--- a/caffeine@patapon.info/metadata.json
+++ b/caffeine@patapon.info/metadata.json
@@ -1,5 +1,5 @@
 {
-"shell-version": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.16", "3.18", "3.20", "3.22"],
+"shell-version": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.16", "3.18", "3.20", "3.22", "3.24"],
 "uuid": "caffeine@patapon.info",
 "name": "Caffeine",
 "settings-schema": "org.gnome.shell.extensions.caffeine",

--- a/caffeine@patapon.info/prefs.js
+++ b/caffeine@patapon.info/prefs.js
@@ -40,71 +40,71 @@ const CaffeineWidget = new Lang.Class({
         this._changedPermitted = false;
 
 
-        let hbox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL,
+        let showCaffeineBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL,
                                 margin: 7});
 
-        let label = new Gtk.Label({label: _("Show Caffeine in top panel"),
+        let showCaffeineLabel = new Gtk.Label({label: _("Show Caffeine in top panel"),
                                            xalign: 0});
 
-        let show = new Gtk.Switch({active: this._settings.get_boolean(SHOW_INDICATOR_KEY)});
-        show.connect('notify::active', Lang.bind(this, function(button) {
+        let showCaffeineSwitch = new Gtk.Switch({active: this._settings.get_boolean(SHOW_INDICATOR_KEY)});
+        showCaffeineSwitch.connect('notify::active', Lang.bind(this, function(button) {
             this._settings.set_boolean(SHOW_INDICATOR_KEY, button.active);
         }));
 
-        hbox.pack_start(label, true, true, 0);
-        hbox.add(show);
+        showCaffeineBox.pack_start(showCaffeineLabel, true, true, 0);
+        showCaffeineBox.add(showCaffeineSwitch);
 
-        this.w.add(hbox);
+        this.w.add(showCaffeineBox);
 
         if (ShellVersion > 6) {
             let hbox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL,
                                     margin: 7});
 
-            let label = new Gtk.Label({label: _("Enable when a fullscreen application is running"),
+            let enableFullscreenLabel = new Gtk.Label({label: _("Enable when a fullscreen application is running"),
                                        xalign: 0});
 
-            let show = new Gtk.Switch({active: this._settings.get_boolean(FULLSCREEN_KEY)});
-            show.connect('notify::active', Lang.bind(this, function(button) {
+            let enableFullscreenSwitch = new Gtk.Switch({active: this._settings.get_boolean(FULLSCREEN_KEY)});
+            enableFullscreenSwitch.connect('notify::active', Lang.bind(this, function(button) {
                 this._settings.set_boolean(FULLSCREEN_KEY, button.active);
             }));
 
-            hbox.pack_start(label, true, true, 0);
-            hbox.add(show);
+            hbox.pack_start(enableFullscreenLabel, true, true, 0);
+            hbox.add(enableFullscreenSwitch);
 
             this.w.add(hbox);
         }
 
-        let hbox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL,
+        let stateBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL,
                                 margin: 7});
 
-        let label = new Gtk.Label({label: _("Restore state across reboots"),
+        let stateLabel = new Gtk.Label({label: _("Restore state across reboots"),
                                    xalign: 0});
 
-        let show = new Gtk.Switch({active: this._settings.get_boolean(RESTORE_KEY)});
-        show.connect('notify::active', Lang.bind(this, function(button) {
+        let stateSwitch = new Gtk.Switch({active: this._settings.get_boolean(RESTORE_KEY)});
+        stateSwitch.connect('notify::active', Lang.bind(this, function(button) {
             this._settings.set_boolean(RESTORE_KEY, button.active);
         }));
 
-        hbox.pack_start(label, true, true, 0);
-        hbox.add(show);
+        stateBox.pack_start(stateLabel, true, true, 0);
+        stateBox.add(stateSwitch);
 
-        this.w.add(hbox);
+        this.w.add(stateBox);
 
-        let hbox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL,
+        let notificationsBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL,
                                 margin: 7});
 
-        let label = new Gtk.Label({label: _("Enable notifications"),
+        let notificationsLabel = new Gtk.Label({label: _("Enable notifications"),
                                    xalign: 0});
 
-        let show = new Gtk.Switch({active: this._settings.get_boolean(SHOW_NOTIFICATIONS_KEY)});
-        show.connect('notify::active', Lang.bind(this, function(button) {
+        let notificationsSwitch = new Gtk.Switch({active: this._settings.get_boolean(SHOW_NOTIFICATIONS_KEY)});
+        notificationsSwitch.connect('notify::active', Lang.bind(this, function(button) {
             this._settings.set_boolean(SHOW_NOTIFICATIONS_KEY, button.active);
         }));
 
-        hbox.pack_start(label, true, true, 0);
-        hbox.add(show);
+        notificationsBox.pack_start(notificationsLabel, true, true, 0);
+        notificationsBox.add(notificationsSwitch);
 
-        this.w.add(hbox);
+        this.w.add(notificationsBox);
 
         this._store = new Gtk.ListStore();
         this._store.set_column_types([Gio.AppInfo, GObject.TYPE_STRING, Gio.Icon]);


### PR DESCRIPTION
This introduces changes required by mozjs38 which appears to be more strict when it comes to syntax rules.

I've also tested the code on Gnome Shell 3.18 and it seems to still be working alright.

One note, I'm not a developer (or a javascript developer) so please, take your time and browse through the changes to see if I didn't mess up something critical here. I've only pieced together the knowledge required to fix the preferences panel for mozjs38.

It seems that [TopIcons Plus had a similar issue](https://github.com/phocean/TopIcons-plus/issues/51) and that allowed me to hack this "fix" together :)

This "fixes" the issue reported in https://github.com/eonpatapon/gnome-shell-extension-caffeine/issues/83

Thanks for developing this awesome extension :+1: 