### PR TITLE
Ignore apps that doesn't report an executable path

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -205,7 +205,7 @@ const Caffeine = new Lang.Class({
                                                              object);
         // Is the new inhibitor Caffeine ?
         inhibitor.GetAppIdRemote(Lang.bind(this, function(app_id) {
-            if (app_id == this._last_app) {
+            if (app_id != '' && app_id == this._last_app) {
                 if (this._last_app == 'user')
                     this._settings.set_boolean(USER_ENABLED_KEY, true);
                 this._apps.push(this._last_app);


### PR DESCRIPTION
It fixes a problem with chrome incognito windows that would get caffeine stuck in inhibit mode.