### PR TITLE
GNOME Shell 3.26 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Fill the cup to inhibit auto suspend and screensaver.
 
-This extension supports gnome-shell 3.4 to 3.22.
+This extension supports gnome-shell 3.4 to 3.26.
 
 Use the gnome-shell-before-3.10 branch for gnome shell 3.4, 3.6 and 3.8.
 

--- a/caffeine@patapon.info/metadata.json
+++ b/caffeine@patapon.info/metadata.json
@@ -1,9 +1,20 @@
 {
-"shell-version": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.16", "3.18", "3.20", "3.22", "3.24"],
-"uuid": "caffeine@patapon.info",
-"name": "Caffeine",
-"settings-schema": "org.gnome.shell.extensions.caffeine",
-"gettext-domain": "gnome-shell-extension-caffeine",
-"description": "Disable the screensaver and auto suspend",
-"url": "https://github.com/eonpatapon/gnome-shell-extension-caffeine"
+  "shell-version": [
+    "3.10",
+    "3.11",
+    "3.12",
+    "3.13",
+    "3.14",
+    "3.16",
+    "3.18",
+    "3.20",
+    "3.22",
+    "3.24"
+  ],
+  "uuid": "caffeine@patapon.info",
+  "name": "Caffeine",
+  "settings-schema": "org.gnome.shell.extensions.caffeine",
+  "gettext-domain": "gnome-shell-extension-caffeine",
+  "description": "Disable the screensaver and auto suspend",
+  "url": "https://github.com/eonpatapon/gnome-shell-extension-caffeine"
 }

--- a/caffeine@patapon.info/metadata.json
+++ b/caffeine@patapon.info/metadata.json
@@ -9,7 +9,8 @@
     "3.18",
     "3.20",
     "3.22",
-    "3.24"
+    "3.24",
+    "3.26"
   ],
   "uuid": "caffeine@patapon.info",
   "name": "Caffeine",


### PR DESCRIPTION
Since a few weeks, I am using the extension with GNOME Shell 3.26 on Arch Linux. While #40 still may appear, I can at least report that it works at least as well as it did with previous version. So I hereby request declaring it compatible.