### PR TITLE
Replace global.screen deprecated in gnome 3.29

### DIFF
--- a/caffeine@patapon.info/convenience.js
+++ b/caffeine@patapon.info/convenience.js
@@ -90,4 +90,8 @@ function getSettings(schema) {
 
     return new Gio.Settings({ settings_schema: schemaObj });
 }
+
+function getDisplay() {
+  return global.screen || global.display;
+}
 								  

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -114,7 +114,10 @@ const Caffeine = new Lang.Class({
 
         // From auto-move-windows@gnome-shell-extensions.gcampax.github.com
         this._windowTracker = Shell.WindowTracker.get_default();
-        let display = global.screen.get_display();
+        let display = Convenience.getDisplay();
+        if (typeof display.get_display === 'function') {
+          display = display.get_display();
+        }
         // Connect after so the handler from ShellWindowTracker has already run
         this._windowCreatedId = display.connect_after('window-created', Lang.bind(this, this._mayInhibit));
         let shellwm = global.window_manager;
@@ -143,7 +146,7 @@ const Caffeine = new Lang.Class({
         }
         // Enable caffeine when fullscreen app is running
         if (this._settings.get_boolean(FULLSCREEN_KEY)) {
-            this._inFullscreenId = global.screen.connect('in-fullscreen-changed', Lang.bind(this, this.toggleFullscreen));
+            this._inFullscreenId = Convenience.getDisplay().connect('in-fullscreen-changed', Lang.bind(this, this.toggleFullscreen));
             this.toggleFullscreen();
         }
         // List current windows to check if we need to inhibit
@@ -153,10 +156,10 @@ const Caffeine = new Lang.Class({
     },
 
     get inFullscreen() {
-        let nb_monitors = global.screen.get_n_monitors();
+        let nb_monitors = Convenience.getDisplay().get_n_monitors();
         let inFullscreen = false;
         for (let i=0; i<nb_monitors; i++) {
-            if (global.screen.get_monitor_in_fullscreen(i)) {
+            if (Convenience.getDisplay().get_monitor_in_fullscreen(i)) {
                 inFullscreen = true;
                 break;
             }
@@ -282,7 +285,7 @@ const Caffeine = new Lang.Class({
         }));
         // disconnect from signals
         if (this._settings.get_boolean(FULLSCREEN_KEY))
-            global.screen.disconnect(this._inFullscreenId);
+            Convenience.getDisplay().disconnect(this._inFullscreenId);
         if (this._inhibitorAddedId) {
             this._sessionManager.disconnectSignal(this._inhibitorAddedId);
             this._inhibitorAddedId = 0;
@@ -292,7 +295,11 @@ const Caffeine = new Lang.Class({
             this._inhibitorRemovedId = 0;
         }
         if (this._windowCreatedId) {
-            global.screen.get_display().disconnect(this._windowCreatedId);
+            let display = Convenience.getDisplay()
+            if (typeof display.get_display === 'function') {
+              display = display.get_display();
+            }
+            display.disconnect(this._windowCreatedId);
             this._windowCreatedId = 0;
         }
         if (this._windowDestroyedId) {


### PR DESCRIPTION
Replaced references to `global.screen` with `global.display` to support gnome 3.29.
This fixes #123.