### PR TITLE
GNOME 3.30 elimates global.screen

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -114,9 +114,18 @@ const Caffeine = new Lang.Class({
 
         // From auto-move-windows@gnome-shell-extensions.gcampax.github.com
         this._windowTracker = Shell.WindowTracker.get_default();
-        let display = global.screen.get_display();
+
+        if (global.screen) {
+            this._screen = global.screen;
+            this._display = this_screen.get_display();
+        }
+        else {
+            this._screen = global.display;
+            this._display = this._screen;
+        }
+
         // Connect after so the handler from ShellWindowTracker has already run
-        this._windowCreatedId = display.connect_after('window-created', Lang.bind(this, this._mayInhibit));
+        this._windowCreatedId = this._display.connect_after('window-created', Lang.bind(this, this._mayInhibit));
         let shellwm = global.window_manager;
         this._windowDestroyedId = shellwm.connect('destroy', Lang.bind(this, this._mayUninhibit));
 
@@ -143,7 +152,7 @@ const Caffeine = new Lang.Class({
         }
         // Enable caffeine when fullscreen app is running
         if (this._settings.get_boolean(FULLSCREEN_KEY)) {
-            this._inFullscreenId = global.screen.connect('in-fullscreen-changed', Lang.bind(this, this.toggleFullscreen));
+            this._inFullscreenId = this._screen.connect('in-fullscreen-changed', Lang.bind(this, this.toggleFullscreen));
             this.toggleFullscreen();
         }
         // List current windows to check if we need to inhibit
@@ -153,10 +162,10 @@ const Caffeine = new Lang.Class({
     },
 
     get inFullscreen() {
-        let nb_monitors = global.screen.get_n_monitors();
+        let nb_monitors = this._screen.get_n_monitors();
         let inFullscreen = false;
         for (let i=0; i<nb_monitors; i++) {
-            if (global.screen.get_monitor_in_fullscreen(i)) {
+            if (this._screen.get_monitor_in_fullscreen(i)) {
                 inFullscreen = true;
                 break;
             }
@@ -282,7 +291,7 @@ const Caffeine = new Lang.Class({
         }));
         // disconnect from signals
         if (this._settings.get_boolean(FULLSCREEN_KEY))
-            global.screen.disconnect(this._inFullscreenId);
+            this._screen.disconnect(this._inFullscreenId);
         if (this._inhibitorAddedId) {
             this._sessionManager.disconnectSignal(this._inhibitorAddedId);
             this._inhibitorAddedId = 0;
@@ -292,7 +301,7 @@ const Caffeine = new Lang.Class({
             this._inhibitorRemovedId = 0;
         }
         if (this._windowCreatedId) {
-            global.screen.get_display().disconnect(this._windowCreatedId);
+            this._display.disconnect(this._windowCreatedId);
             this._windowCreatedId = 0;
         }
         if (this._windowDestroyedId) {


### PR DESCRIPTION
Fixes bug https://github.com/eonpatapon/gnome-shell-extension-caffeine/issues/123.

I suggest this as a neater and more efficient version of
pull request https://github.com/eonpatapon/gnome-shell-extension-caffeine/pull/124.