### PR TITLE
Fix checking global.screen (repairs 3.28)

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -114,8 +114,9 @@ const Caffeine = new Lang.Class({
 
         // From auto-move-windows@gnome-shell-extensions.gcampax.github.com
         this._windowTracker = Shell.WindowTracker.get_default();
-
-        if ("screen" in global) {
+        
+        // ("screen" in global) is false on 3.28, although global.screen exists
+        if (typeof global.screen !== "undefined") {
             this._screen = global.screen;
             this._display = this._screen.get_display();
         }


### PR DESCRIPTION
Otherwise, `("screen" in global)` is `false` and the extension breaks with

```
Error: No signal 'in-fullscreen-changed' on object 'MetaDisplay'
```

[StackOverflow-driven development.](https://stackoverflow.com/questions/27509/detecting-an-undefined-object-property) Please test on 3.30+.

Signed-off-by: Vadim Markovtsev <vadim@sourced.tech>