### PR TITLE
Fix `shell-version` data in `metadata.json`

### DIFF
--- a/caffeine@patapon.info/metadata.json
+++ b/caffeine@patapon.info/metadata.json
@@ -1,8 +1,5 @@
 {
   "shell-version": [
-    "3.26",
-    "3.28",
-    "3.30",
     "3.32"
   ],
   "uuid": "caffeine@patapon.info",


### PR DESCRIPTION
As @jagaudin and @mirko-laruina have pointed out in #139 , `GObject.registerClass` is available since `1.49.90` (gjs version). The first gnome-shell which requires an equal or higher version is `3.31.92`.

This PR erases not supported gnome-shell versions.

Sorry for the inconveniences that caused by the refactor!  