### PR TITLE
Declare support for gnome-shell 3.34

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 Fill the cup to inhibit auto suspend and screensaver.
 
-This extension supports gnome-shell 3.4 to 3.32:
+This extension supports gnome-shell 3.4 to 3.34:
 
-    * master: 3.2
+    * master: 3.32 -> 3.34
     * gnome-shell-3.10-3.30: 3.10 -> 3.30
     * gnome-shell-before-3.10: 3.4 -> 3.8
 

--- a/caffeine@patapon.info/metadata.json
+++ b/caffeine@patapon.info/metadata.json
@@ -1,6 +1,7 @@
 {
   "shell-version": [
-    "3.32"
+    "3.32",
+    "3.34"
   ],
   "uuid": "caffeine@patapon.info",
   "name": "Caffeine",


### PR DESCRIPTION
Caffeine works on 3.34 without modification, so add it to the list of supported versions.

Fixes #146.