### PR TITLE
Add pause and resume of Night Light + Wayland fix

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -210,21 +210,11 @@ class Caffeine extends PanelMenu.Button {
     toggleState() {
         if (this._state) {
             this._apps.forEach(app_id => this.removeInhibit(app_id));
-            if (this._settings.get_boolean(NIGHT_LIGHT_KEY) && this._proxy.NightLightActive && !this._settings.get_boolean(NIGHT_LIGHT_APP_ONLY_KEY)) {
-                this._proxy.DisabledUntilTomorrow = false;
-                this._night_light = true;
-            } else {
-                this._night_light = false;
-            }
+            this._manageNightLight('enabled');
         }
         else {
             this.addInhibit('user');
-            if (this._settings.get_boolean(NIGHT_LIGHT_KEY) && this._proxy.NightLightActive && !this._settings.get_boolean(NIGHT_LIGHT_APP_ONLY_KEY)) {
-                this._proxy.DisabledUntilTomorrow = true;
-                this._night_light = true;
-            } else {
-                this._night_light = false;
-            }
+            this._manageNightLight('disabled');
         }
     }
 
@@ -287,6 +277,25 @@ class Caffeine extends PanelMenu.Button {
                     this._sendNotification('disabled');
                 }
             }
+        }
+    }
+
+    _manageNightLight(state){
+        if (state == 'enabled') {
+          if (this._settings.get_boolean(NIGHT_LIGHT_KEY) && this._proxy.NightLightActive && !this._settings.get_boolean(NIGHT_LIGHT_APP_ONLY_KEY)) {
+              this._proxy.DisabledUntilTomorrow = false;
+              this._night_light = true;
+          } else {
+              this._night_light = false;
+          }
+        }
+        if (state == 'disabled') {
+          if (this._settings.get_boolean(NIGHT_LIGHT_KEY) && this._proxy.NightLightActive && !this._settings.get_boolean(NIGHT_LIGHT_APP_ONLY_KEY)) {
+              this._proxy.DisabledUntilTomorrow = true;
+              this._night_light = true;
+          } else {
+              this._night_light = false;
+          }
         }
     }
 

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -112,8 +112,12 @@ class Caffeine extends PanelMenu.Button {
         this._inhibitorRemovedId = this._sessionManager.connectSignal('InhibitorRemoved', this._inhibitorRemoved.bind(this));
 
         // From auto-move-windows@gnome-shell-extensions.gcampax.github.com
-        this._windowTracker = Shell.WindowTracker.get_default();
-        
+        this._appSystem = Shell.AppSystem.get_default();
+
+        this._appsChangedId =
+            this._appSystem.connect('installed-changed',
+                this._updateAppData.bind(this));
+
         // ("screen" in global) is false on 3.28, although global.screen exists
         if (typeof global.screen !== "undefined") {
             this._screen = global.screen;
@@ -123,11 +127,6 @@ class Caffeine extends PanelMenu.Button {
             this._screen = global.display;
             this._display = this._screen;
         }
-
-        // Connect after so the handler from ShellWindowTracker has already run
-        this._windowCreatedId = this._display.connect_after('window-created', this._mayInhibit.bind(this));
-        let shellwm = global.window_manager;
-        this._windowDestroyedId = shellwm.connect('destroy', this._mayUninhibit.bind(this));
 
         this._icon = new St.Icon({
             style_class: 'system-status-icon'
@@ -156,10 +155,12 @@ class Caffeine extends PanelMenu.Button {
             this._inFullscreenId = this._screen.connect('in-fullscreen-changed', this.toggleFullscreen.bind(this));
             this.toggleFullscreen();
         }
-        // List current windows to check if we need to inhibit
-        global.get_window_actors().map(window => {
-            this._mayInhibit(null, window.meta_window, null);
-        });
+
+        this._appConfigs = [];
+        this._appData = new Map();
+
+        this._settings.connect(`changed::${INHIBIT_APPS_KEY}`, this._updateAppConfigs.bind(this));
+        this._updateAppConfigs();
     }
 
     get inFullscreen() {
@@ -255,31 +256,57 @@ class Caffeine extends PanelMenu.Button {
         }
     }
 
-    _mayInhibit(display, window, noRecurse) {
-        let app = this._windowTracker.get_window_app(window);
-        if (!app) {
-            if (!noRecurse) {
-                // window is not tracked yet
-                Mainloop.idle_add(() => {
-                    this._mayInhibit(display, window, true);
-                    return false;
-                });
-            }
-            return;
-        }
-        let app_id = app.get_id();
-        let apps = this._settings.get_strv(INHIBIT_APPS_KEY);
-        if (apps.includes(app_id))
-            this.addInhibit(app_id);
+    _updateAppConfigs() {
+        this._appConfigs.length = 0;
+        this._settings.get_strv(INHIBIT_APPS_KEY).forEach(appId => {
+            this._appConfigs.push(appId);
+        });
+        this._updateAppData();
     }
 
-    _mayUninhibit(shellwm, actor) {
-        let window = actor.meta_window;
-        let app = this._windowTracker.get_window_app(window);
-        if (app) {
-            let app_id = app.get_id();
-            if (this._apps.includes(app_id))
-                this.removeInhibit(app_id);
+    _updateAppData() {
+        let ids = this._appConfigs.slice()
+        let removedApps = [...this._appData.keys()]
+            .filter(a => !ids.includes(a.id));
+        removedApps.forEach(app => {
+            app.disconnect(this._appData.get(app).windowsChangedId);
+            let id = app.get_id();
+            this._appData.delete(app);
+        });
+        let addedApps = ids
+            .map(id => this._appSystem.lookup_app(id))
+            .filter(app => app && !this._appData.has(app));
+        addedApps.forEach(app => {
+            let data = {
+                windowsChangedId: app.connect('windows-changed',
+                    this._appWindowsChanged.bind(this)),
+            };
+            let id = app.get_id();
+            this._appData.set(app, data);
+        });
+    }
+
+    _appWindowsChanged(app) {
+        let app_id = app.get_id();
+        let appState = app.get_state();
+        // app is STARTING (1) or RUNNING (2)
+        if ((appState == 1) || (appState == 2)) {
+            this.addInhibit(app_id);
+            if (this._settings.get_boolean(NIGHT_LIGHT_KEY) && this._proxy.NightLightActive) {
+                this._proxy.DisabledUntilTomorrow = true;
+                this._night_light = true;
+            } else {
+                this._night_light = false;
+            }
+        // app is STOPPED (0)
+        } else {
+            this.removeInhibit(app_id);
+            if (this._settings.get_boolean(NIGHT_LIGHT_KEY) && this._proxy.NightLightActive) {
+                this._proxy.DisabledUntilTomorrow = false;
+                this._night_light = true;
+            } else {
+                this._night_light = false;
+            }
         }
     }
 
@@ -305,6 +332,12 @@ class Caffeine extends PanelMenu.Button {
             global.window_manager.disconnect(this._windowDestroyedId);
             this._windowDestroyedId = 0;
         }
+        if (this._appsChangedId) {
+            this._appSystem.disconnect(this._appsChangedId);
+            this._appsChangedId = 0;
+        }
+        this._appConfigs.length = 0;
+        this._updateAppData();
         super.destroy();
     }
 });

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -261,8 +261,9 @@ class Caffeine extends PanelMenu.Button {
                         if (this._state === false) {
                             this._state = true;
                             this._icon.gicon = Gio.icon_new_for_string(`${Me.path}/icons/${EnabledIcon}.svg`);
-                            if (this._settings.get_boolean(SHOW_NOTIFICATIONS_KEY) && !this.inFullscreen)
-                                Main.notify(_('Auto suspend and screensaver disabled'));
+                            if (this._settings.get_boolean(SHOW_NOTIFICATIONS_KEY) && !this.inFullscreen) {
+                                this._sendNotification('enabled');
+                            }
                         }
                     }
                 });
@@ -282,8 +283,26 @@ class Caffeine extends PanelMenu.Button {
             if (this._apps.length === 0) {
                 this._state = false;
                 this._icon.gicon = Gio.icon_new_for_string(`${Me.path}/icons/${DisabledIcon}.svg`);
-                if(this._settings.get_boolean(SHOW_NOTIFICATIONS_KEY))
-                    Main.notify(_('Auto suspend and screensaver enabled'));
+                if(this._settings.get_boolean(SHOW_NOTIFICATIONS_KEY)) {
+                    this._sendNotification('disabled');
+                }
+            }
+        }
+    }
+
+    _sendNotification(state){
+        if (state == 'enabled') {
+          if (this._settings.get_boolean(NIGHT_LIGHT_KEY) && this._night_light && this._proxy.DisabledUntilTomorrow) {
+              Main.notify(_('Auto suspend and screensaver disabled. Night Light paused.'));
+          } else {
+              Main.notify(_('Auto suspend and screensaver disabled'));
+          }
+        }
+        if (state == 'disabled') {
+            if (this._settings.get_boolean(NIGHT_LIGHT_KEY) && this._night_light && !this._proxy.DisabledUntilTomorrow) {
+                Main.notify(_('Auto suspend and screensaver enabled. Night Light resumed.'));
+            } else {
+                Main.notify(_('Auto suspend and screensaver enabled'));
             }
         }
     }

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -197,13 +197,15 @@ class Caffeine extends PanelMenu.Button {
 
     toggleFullscreen() {
         Mainloop.timeout_add_seconds(2, () => {
-          if (this.inFullscreen && !this._apps.includes('fullscreen')) {
-              this.addInhibit('fullscreen');
-          }
+            if (this.inFullscreen && !this._apps.includes('fullscreen')) {
+                this.addInhibit('fullscreen');
+                this._manageNightLight('disabled');
+            }
         });
 
         if (!this.inFullscreen && this._apps.includes('fullscreen')) {
-              this.removeInhibit('fullscreen');
+            this.removeInhibit('fullscreen');
+            this._manageNightLight('enabled');
         }
     }
 

--- a/caffeine@patapon.info/prefs.js
+++ b/caffeine@patapon.info/prefs.js
@@ -18,6 +18,8 @@ const SHOW_INDICATOR_KEY = 'show-indicator';
 const SHOW_NOTIFICATIONS_KEY = 'show-notifications';
 const FULLSCREEN_KEY = 'enable-fullscreen';
 const RESTORE_KEY = 'restore-state';
+const NIGHT_LIGHT_KEY = 'control-nightlight';
+const NIGHT_LIGHT_APP_ONLY_KEY = 'control-nightlight-for-app';
 
 const Columns = {
     APPINFO: 0,
@@ -102,6 +104,46 @@ class CaffeineWidget {
         notificationsBox.add(notificationsSwitch);
 
         this.w.add(notificationsBox);
+
+        const nightlightBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL,
+                                margin: 7});
+
+        const nightlightLabel = new Gtk.Label({label: _("Pause/resume Night Light if enabled"),
+                                   xalign: 0});
+
+        const nightlightSwitch = new Gtk.Switch({active: this._settings.get_boolean(NIGHT_LIGHT_KEY)});
+        nightlightSwitch.connect('notify::active', button => {
+            this._settings.set_boolean(NIGHT_LIGHT_KEY, button.active);
+        });
+
+        nightlightBox.pack_start(nightlightLabel, true, true, 0);
+        nightlightBox.add(nightlightSwitch);
+
+        this.w.add(nightlightBox);
+
+        const nightlightAppBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL,
+                                margin: 7});
+
+        const nightlightAppLabel = new Gtk.Label({label: _("Pause/resume Night Light for defined applications only"),
+                                   xalign: 0});
+
+        const nightlightAppSwitch = new Gtk.Switch({active: this._settings.get_boolean(NIGHT_LIGHT_APP_ONLY_KEY)});
+        nightlightAppSwitch.connect('notify::active', button => {
+            this._settings.set_boolean(NIGHT_LIGHT_APP_ONLY_KEY, button.active);
+        });
+        nightlightSwitch.connect('notify::active', button => {
+          if (button.active) {
+            nightlightAppSwitch.set_sensitive(true);
+          } else {
+              nightlightAppSwitch.set_active(false);
+              nightlightAppSwitch.set_sensitive(false);
+          }
+        });
+
+        nightlightAppBox.pack_start(nightlightAppLabel, true, true, 0);
+        nightlightAppBox.add(nightlightAppSwitch);
+
+        this.w.add(nightlightAppBox);
 
         this._store = new Gtk.ListStore();
         this._store.set_column_types([Gio.AppInfo, GObject.TYPE_STRING, Gio.Icon]);

--- a/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
+++ b/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
@@ -31,5 +31,15 @@
         <summary>Enable when a fullscreen application is running</summary>
         <description>Enable when a fullscreen application is running</description>
     </key>
+    <key type="b" name="control-nightlight">
+        <default>false</default>
+        <summary>Pause/resume Night Light</summary>
+        <description>Pause/resume Night Light when enabled/disabled</description>
+    </key>
+    <key type="b" name="control-nightlight-for-app">
+        <default>false</default>
+        <summary>Pause/resume Night Light for defined applications only</summary>
+        <description>Pause/resume Night Light for defined applicationa when enabled/disabled</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
**Night Light**

Fixes #133 

Add two switches for Night Light. One switch to enable it globally and one to limit for defined applications only.

Night Light disabled. Second switch greyed out:
![image](https://user-images.githubusercontent.com/8488565/95896732-06c42600-0d8d-11eb-9ca9-af4a29a5811e.png)

Night light enabled. Night Light paused/resumed when caffeine is enabled/disabled:
![image](https://user-images.githubusercontent.com/8488565/95896812-29563f00-0d8d-11eb-8aa2-2c49eb39248e.png)

Night light enabled, but only for defined applications. Night Light paused/resumed when application is started/stopped only:
![image](https://user-images.githubusercontent.com/8488565/95896642-d3819700-0d8c-11eb-82b3-bb9c322d22cd.png)


**Applications and Wayland**

Fixes #163 

Applications can now enable/disable Caffeine on Wayland.

![image](https://user-images.githubusercontent.com/8488565/96161103-28e9af80-0f17-11eb-8bbb-d2f19eff4575.png)
