### PR TITLE
Changing the shell version

### DIFF
--- a/caffeine@patapon.info/metadata.json
+++ b/caffeine@patapon.info/metadata.json
@@ -1,8 +1,7 @@
 {
   "version": 38,
   "shell-version": [
-    "40.1",
-    "40.0"
+    "40"
   ],
   "uuid": "caffeine@patapon.info",
   "name": "Caffeine",


### PR DESCRIPTION
There's no need to add the subversion here, and using a plain "40" supports all versions of GNOME 40.