### PR TITLE
Gnome 42 Compatibility

### DIFF
--- a/caffeine@patapon.info/metadata.json
+++ b/caffeine@patapon.info/metadata.json
@@ -2,7 +2,8 @@
   "version": 39,
   "shell-version": [
     "40",
-    "41"
+    "41",
+    "42"
   ],
   "uuid": "caffeine@patapon.info",
   "name": "Caffeine",


### PR DESCRIPTION
Tested on Fedora 36 Beta.

Signed-off-by: Felix Kaechele <felix@kaechele.ca>