### PR TITLE
Corrected extension version in metadata to match uploaded version

### DIFF
--- a/caffeine@patapon.info/metadata.json
+++ b/caffeine@patapon.info/metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": 39,
+  "version": 40,
   "shell-version": [
     "40",
     "41",


### PR DESCRIPTION
Currently the version of the extensions on e.g.o is 40, so building from source triggers gnome-shell to falsely 'update' to an older version
Even though this isn't a new release, merging this brings the repo and site inline, so installing from source won't be overwritten