### PR TITLE
Update README for version and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 Fill the cup to inhibit auto suspend and screensaver.
 
-This extension supports gnome-shell 3.4 to 41
+This extension supports gnome-shell 3.4 to 42
 
-* master: 40 -> 41
+* master: 40 -> 42
 * gnome-shell-3.36-3.38: 3.36 -> 3.38
 * gnome-shell-3.32-3.34: 3.32 -> 3.34
 * gnome-shell-3.10-3.30: 3.10 -> 3.30

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ screensaver off.
 https://extensions.gnome.org/extension/517/caffeine/
 
 ## Installation from git
-
+```
+make build
+make install
+```
+Alternatively:
 ```sh
 git clone git://github.com/eonpatapon/gnome-shell-extension-caffeine.git
 cd gnome-shell-extension-caffeine

--- a/README.md
+++ b/README.md
@@ -28,13 +28,5 @@ https://extensions.gnome.org/extension/517/caffeine/
 make build
 make install
 ```
-Alternatively:
-```sh
-git clone git://github.com/eonpatapon/gnome-shell-extension-caffeine.git
-cd gnome-shell-extension-caffeine
-./update-locale.sh
-glib-compile-schemas --strict --targetdir=caffeine@patapon.info/schemas/ caffeine@patapon.info/schemas
-cp -r caffeine@patapon.info ~/.local/share/gnome-shell/extensions
-```
 
 Restart the shell and then enable the extension.


### PR DESCRIPTION
 - As GNOME 42 is supported by the extension, the README has been updated to actually list support for it
 - A set of instructions to build and install the extension using `make` has also been added, for simplicity