### PR TITLE
Add terminal support

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -169,10 +169,15 @@ class Caffeine extends PanelMenu.Button {
             this.toggleFullscreen();
         }
 
+        // Sync saved state with local state
+        this._settings.set_boolean(USER_ENABLED_KEY, this._state);
+
         this._appConfigs = [];
         this._appData = new Map();
 
         this._settings.connect(`changed::${INHIBIT_APPS_KEY}`, this._updateAppConfigs.bind(this));
+        this._settings.connect(`changed::${USER_ENABLED_KEY}`, this._updateState.bind(this));
+
         this._updateAppConfigs();
     }
 
@@ -315,6 +320,11 @@ class Caffeine extends PanelMenu.Button {
             this._appConfigs.push(appId);
         });
         this._updateAppData();
+    }
+
+    _updateState() {
+        if (this._settings.get_boolean(USER_ENABLED_KEY) != this._state)
+            this.toggleState();
     }
 
     _updateAppData() {


### PR DESCRIPTION
- Fixes #148 
- Get current state: `gsettings --schemadir ~/.local/share/gnome-shell/extensions/caffeine@patapon.info/schemas/ get org.gnome.shell.extensions.caffeine user-enabled`
- Enable: `gsettings --schemadir ~/.local/share/gnome-shell/extensions/caffeine@patapon.info/schemas/ set org.gnome.shell.extensions.caffeine user-enabled true`
- Disable: `gsettings --schemadir ~/.local/share/gnome-shell/extensions/caffeine@patapon.info/schemas/ set org.gnome.shell.extensions.caffeine user-enabled false`

`--schemadir` must be a path to the extension `schemas` directory. It may be different on your system.