### PR TITLE
Add terminal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,20 @@ make install
 ```
   - Restart the shell
   - Enable the extension
+
+## CLI
+
+- Get current state:
+  ```sh
+  gsettings --schemadir ~/.local/share/gnome-shell/extensions/caffeine@patapon.info/schemas/ get org.gnome.shell.extensions.caffeine user-enabled
+  ```
+- Enable Caffeine:
+  ```sh
+  gsettings --schemadir ~/.local/share/gnome-shell/extensions/caffeine@patapon.info/schemas/ set org.gnome.shell.extensions.caffeine user-enabled true
+  ```
+- Disable Caffeine:
+  ```sh
+  gsettings --schemadir ~/.local/share/gnome-shell/extensions/caffeine@patapon.info/schemas/ set org.gnome.shell.extensions.caffeine user-enabled false
+  ```
+
+`--schemadir` — path to the extension schemas directory. It may be different on your system.

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -174,7 +174,7 @@ class Caffeine extends PanelMenu.Button {
         this._appData = new Map();
 
         this._settings.connect(`changed::${INHIBIT_APPS_KEY}`, this._updateAppConfigs.bind(this));
-        this._settings.connect(`changed::${USER_ENABLED_KEY}`, this._updateState.bind(this));
+        this._settings.connect(`changed::${USER_ENABLED_KEY}`, this._updateUserState.bind(this));
 
         this._updateAppConfigs();
     }
@@ -320,7 +320,7 @@ class Caffeine extends PanelMenu.Button {
         this._updateAppData();
     }
 
-    _updateState() {
+    _updateUserState() {
         if (this._settings.get_boolean(USER_ENABLED_KEY) !== this._userState) {
             this._userState = !this._userState;
             this.toggleState();

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -321,8 +321,10 @@ class Caffeine extends PanelMenu.Button {
     }
 
     _updateState() {
-        if (this._settings.get_boolean(USER_ENABLED_KEY) !== this._userState)
+        if (this._settings.get_boolean(USER_ENABLED_KEY) !== this._userState) {
+            this._userState = !this._userState;
             this.toggleState();
+        }
     }
 
     _saveUserState(state) {

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -147,6 +147,7 @@ class Caffeine extends PanelMenu.Button {
         this._icon.gicon = Gio.icon_new_for_string(`${Me.path}/icons/${DisabledIcon}.svg`);
 
         this._state = false;
+        this._userState = false;
         // who has requested the inhibition
         this._last_app = '';
         this._last_cookie = '';
@@ -173,6 +174,8 @@ class Caffeine extends PanelMenu.Button {
         this._appData = new Map();
 
         this._settings.connect(`changed::${INHIBIT_APPS_KEY}`, this._updateAppConfigs.bind(this));
+        this._settings.connect(`changed::${USER_ENABLED_KEY}`, this._updateState.bind(this));
+
         this._updateAppConfigs();
     }
 
@@ -237,7 +240,7 @@ class Caffeine extends PanelMenu.Button {
                     appId = String(appId);
                     if (appId !== '' && appId === this._last_app) {
                         if (this._last_app === 'user')
-                            this._settings.set_boolean(USER_ENABLED_KEY, true);
+                            this._saveUserState(true);
                         this._apps.push(this._last_app);
                         this._cookies.push(this._last_cookie);
                         this._objects.push(object);
@@ -259,7 +262,7 @@ class Caffeine extends PanelMenu.Button {
         let index = this._objects.indexOf(object);
         if (index !== -1) {
             if (this._apps[index] === 'user')
-                this._settings.set_boolean(USER_ENABLED_KEY, false);
+                this._saveUserState(false);
             // Remove app from list
             this._apps.splice(index, 1);
             this._cookies.splice(index, 1);
@@ -315,6 +318,16 @@ class Caffeine extends PanelMenu.Button {
             this._appConfigs.push(appId);
         });
         this._updateAppData();
+    }
+
+    _updateState() {
+        if (this._settings.get_boolean(USER_ENABLED_KEY) !== this._userState)
+            this.toggleState();
+    }
+
+    _saveUserState(state) {
+        this._userState = state;
+        this._settings.set_boolean(USER_ENABLED_KEY, state);
     }
 
     _updateAppData() {


### PR DESCRIPTION
Had so much fun with states.

- Fixes #148
- Fixes #189
- Get current state: `gsettings --schemadir ~/.local/share/gnome-shell/extensions/caffeine@patapon.info/schemas/ get org.gnome.shell.extensions.caffeine user-enabled`
- Enable: `gsettings --schemadir ~/.local/share/gnome-shell/extensions/caffeine@patapon.info/schemas/ set org.gnome.shell.extensions.caffeine user-enabled true`
- Disable: `gsettings --schemadir ~/.local/share/gnome-shell/extensions/caffeine@patapon.info/schemas/ set org.gnome.shell.extensions.caffeine user-enabled false`

`--schemadir` must be a path to the extension `schemas` directory. It may be different on your system.