### PR TITLE
Allow screen blank

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -31,6 +31,7 @@ const USER_ENABLED_KEY = 'user-enabled';
 const RESTORE_KEY = 'restore-state';
 const FULLSCREEN_KEY = 'enable-fullscreen';
 const NIGHT_LIGHT_KEY = 'control-nightlight';
+const SCREEN_BLANK = 'screen-blank';
 
 const Gettext = imports.gettext.domain('gnome-shell-extension-caffeine');
 const _ = Gettext.gettext;
@@ -216,8 +217,13 @@ class Caffeine extends PanelMenu.Button {
     }
 
     addInhibit(appId) {
+        let inhibitFlags = 12
+        if (this._settings.get_boolean(SCREEN_BLANK)) {
+            inhibitFlags = 4
+        }
+
         this._sessionManager.InhibitRemote(appId,
-            0, 'Inhibit by %s'.format(IndicatorName), 12,
+            0, 'Inhibit by %s'.format(IndicatorName), inhibitFlags,
             cookie => {
                 this._last_cookie = cookie;
                 this._last_app = appId;

--- a/caffeine@patapon.info/prefs.js
+++ b/caffeine@patapon.info/prefs.js
@@ -17,6 +17,7 @@ const SettingsKey = {
     FULLSCREEN: 'enable-fullscreen',
     RESTORE: 'restore-state',
     NIGHT_LIGHT: 'nightlight-control',
+    SCREENBLANK: 'screen-blank',
 };
 
 const SettingListBoxRow = GObject.registerClass({
@@ -148,6 +149,10 @@ const SettingsPane = GObject.registerClass(
                 ],
             });
             _listBox.append(_controlNightlight);
+
+            const _screenBlank = new SettingListBoxRow(_('Allow screen blank'), _('Allow turning off screen when Caffeine is enabled'), SettingsKey.SCREENBLANK);
+            _listBox.append(_screenBlank);
+
         }
 
         _rowActivated(widget, row) {

--- a/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
+++ b/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
@@ -52,5 +52,11 @@
         <summary>Night Light control mode</summary>
         <description>Set the way Caffeine interacts with the Night light setting.</description>
     </key>
+    <key type="b" name="screen-blank">
+        <default>false</default>
+        <summary>Allow screen blank</summary>
+        <description>Allow turning off screen when Caffeine is enabled</description>
+    </key>
+
   </schema>
 </schemalist>


### PR DESCRIPTION
Note: Remember State should also enabled

Implements: https://github.com/eonpatapon/gnome-shell-extension-caffeine/issues/188