### PR TITLE
Allow screen blank

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -32,6 +32,7 @@ const RESTORE_KEY = 'restore-state';
 const FULLSCREEN_KEY = 'enable-fullscreen';
 const NIGHT_LIGHT_KEY = 'control-nightlight';
 const TOGGLE_SHORTCUT = 'toggle-shortcut';
+const SCREEN_BLANK = 'screen-blank';
 
 const Gettext = imports.gettext.domain('gnome-shell-extension-caffeine');
 const _ = Gettext.gettext;
@@ -217,8 +218,13 @@ class Caffeine extends PanelMenu.Button {
     }
 
     addInhibit(appId) {
+        let inhibitFlags = 12
+        if (this._settings.get_boolean(SCREEN_BLANK)) {
+            inhibitFlags = 4
+        }
+
         this._sessionManager.InhibitRemote(appId,
-            0, 'Inhibit by %s'.format(IndicatorName), 12,
+            0, 'Inhibit by %s'.format(IndicatorName), inhibitFlags,
             cookie => {
                 this._last_cookie = cookie;
                 this._last_app = appId;

--- a/caffeine@patapon.info/locale/cs/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/cs/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 01:39+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2022-04-13 15:18+0200\n"
 "Last-Translator: Daniel Rusek <mail@asciiwolf.com>\n"
 "Language-Team: Czech\n"
@@ -17,102 +17,111 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:304
+#: extension.js:310
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr ""
 "Automatické uspání a šetřič obrazovky jsou zakázané. Noční světlo "
 "pozastaveno."
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "Automatické uspání a šetřič obrazovky jsou zakázané"
 
-#: extension.js:310
+#: extension.js:316
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr ""
 "Automatické uspání a šetřič obrazovky jsou povolené. Noční světlo obnoveno."
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "Automatické uspání a šetřič obrazovky jsou povolené"
 
-#: prefs.js:138
+#: prefs.js:139
 msgid "Show status indicator in top panel"
 msgstr "Zobrazit indikátor stavu v horní liště"
 
-#: prefs.js:138
+#: prefs.js:139
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "Povolit nebo zakázat ikonu Caffeine v horní liště"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Notifications"
 msgstr "Upozornění"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr "Povolit upozornění, když je Caffeine povoleno nebo zakázáno"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr "Pamatovat stav"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember the last state across sessions and reboots"
 msgstr "Pamatovat si poslední stav mezi sezeními a restarty"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Enable for fullscreen apps"
 msgstr "Povolit pro celoobrazovkové aplikace"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "Automaticky povolit, když aplikace přejde do režimu celé obrazovky"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Pause and resume Night Light"
 msgstr "Pozastavit a obnovit Noční světlo"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Přepne noční světlo spolu se stavem Caffeine"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr "Nikdy"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr "Vždy"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr "Pro aplikace na seznamu"
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#, fuzzy
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr "Povolit upozornění, když je Caffeine povoleno nebo zakázáno"
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr "Aplikace, které spouštějí Caffeine"
 
-#: prefs.js:361
+#: prefs.js:365
 msgid "Add Application"
 msgstr "Přidat aplikaci"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr "Obecné"
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr "Aplikace"
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/de/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/de/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 01:39+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2021-04-09 21:31-0400\n"
 "Last-Translator: Felix Kaechele <felix@kaechele.ca>\n"
 "Language-Team: German\n"
@@ -17,101 +17,110 @@ msgstr ""
 "X-Generator: Poedit 2.4.2\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:304
+#: extension.js:310
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr ""
 "Bereitschaftsmodus und Bildschirmschoner deaktiviert. Nachtmodus pausiert."
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "Bereitschaftsmodus und Bildschirmschoner deaktiviert"
 
-#: extension.js:310
+#: extension.js:316
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr ""
 "Bereitschaftsmodus und Bildschirmschoner aktiviert. Nachtmodus fortgesetzt."
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "Bereitschaftsmodus und Bildschirmschoner aktiviert"
 
-#: prefs.js:138
+#: prefs.js:139
 msgid "Show status indicator in top panel"
 msgstr "Indikator-Icon in der oberen Leiste anzeigen"
 
-#: prefs.js:138
+#: prefs.js:139
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "Aktiviert oder deaktiviert das Caffeine Icon in der oberen Leiste"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Notifications"
 msgstr "Benachrichtigungen"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr "Benachrichtigungen anzeigen, wenn aktiviert/deaktiviert"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr "Zustand wiederherstellen"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember the last state across sessions and reboots"
 msgstr "Nach einem Neustart den Zustand wiederherstellen"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Enable for fullscreen apps"
 msgstr "Aktiviere für Vollbild Anwendungen"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "Automatisch aktivieren wenn Anwendung in den Vollbildmodus wechselt"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Pause and resume Night Light"
 msgstr "Nachtmodus unterbrechen"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Unterbricht den Nachtmodus wenn Caffeine aktiviert wird"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr "Nie"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr "Immer"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr "Für Apps auf Liste"
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#, fuzzy
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr "Benachrichtigungen anzeigen, wenn aktiviert/deaktiviert"
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr "Anwendungen, die Caffeine aktivieren"
 
-#: prefs.js:361
+#: prefs.js:365
 msgid "Add Application"
 msgstr "Anwendung hinzufügen"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr "Allgemein"
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr "Anwendungen"
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/es/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/es/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 01:39+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2015-11-28 21:06-0300\n"
 "Last-Translator: Sergio D. Márquez <marquez.sergio.d@gmail.com>\n"
 "Language-Team: Spanish\n"
@@ -17,109 +17,118 @@ msgstr ""
 "X-Generator: Poedit 1.8.6\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:304
+#: extension.js:310
 #, fuzzy
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr "Auto suspensión y salvapantallas deshabilitados"
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "Auto suspensión y salvapantallas deshabilitados"
 
-#: extension.js:310
+#: extension.js:316
 #, fuzzy
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr "Auto suspensión y salvapantallas habilitados"
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "Auto suspensión y salvapantallas habilitados"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Show status indicator in top panel"
 msgstr "Mostrar Caffeine en el panel superior"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "Mostrar Caffeine en el panel superior"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Notifications"
 msgstr "Activar las notificaciones"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr "Mostrar notificaciones de habilitado/deshabilitado"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr ""
 
-#: prefs.js:144
+#: prefs.js:145
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "Restablecer estado despues de reiniciar"
 
-#: prefs.js:147
+#: prefs.js:148
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Activar cuando una aplicación a pantalla completa esté en ejecución"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: prefs.js:150
+#: prefs.js:151
 #, fuzzy
 msgid "Pause and resume Night Light"
 msgstr "Mostrar notificaciones de habilitado/deshabilitado"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr ""
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#, fuzzy
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr "Mostrar notificaciones de habilitado/deshabilitado"
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr ""
 
-#: prefs.js:361
+#: prefs.js:365
 #, fuzzy
 msgid "Add Application"
 msgstr "Agregar aplicación"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr ""
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr ""
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 01:39+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2022-10-07 16:40+0200\n"
 "Last-Translator: Simon Elst <kirmaha@duck.com>\n"
 "Language-Team: French\n"
@@ -22,99 +22,111 @@ msgstr ""
 "X-Generator: Poedit 3.1.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:304
+#: extension.js:310
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr "Mise en veille et écran de veille désactivés. Mode nuit suspendu."
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "Mise en veille et écran de veille désactivés"
 
-#: extension.js:310
+#: extension.js:316
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr "Mise en veille et écran de veille activés. Mode nuit réactivé."
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "Mise en veille et écran de veille activés"
 
-#: prefs.js:138
+#: prefs.js:139
 msgid "Show status indicator in top panel"
 msgstr "Afficher l’indicateur d’état dans la barre supérieure"
 
-#: prefs.js:138
+#: prefs.js:139
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "Activer ou désactiver l’icône de Caféine dans la barre supérieure"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Notifications"
 msgstr "Notifications"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr "Activer les notifications quand Caféine est activé ou désactivé"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr "Se souvenir de l’état"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember the last state across sessions and reboots"
-msgstr "Se souvenir du dernier état au-delà des changements de session et redémarrages"
+msgstr ""
+"Se souvenir du dernier état au-delà des changements de session et "
+"redémarrages"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Enable for fullscreen apps"
 msgstr "Activer pour les applications en plein écran"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
-msgstr "Activer automatiquement lorsqu’une application entre en mode plein écran"
+msgstr ""
+"Activer automatiquement lorsqu’une application entre en mode plein écran"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Pause and resume Night Light"
 msgstr "Suspendre et réactiver le Mode nuit"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Commute le Mode nuit en fonction de l’état de Caféine"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr "Jamais"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr "Toujours"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr "Pour les applications de la liste"
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr "Raccourci de commutation"
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr "Utiliser Retour arrière pour effacer"
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#, fuzzy
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr "Activer les notifications quand Caféine est activé ou désactivé"
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr "Applications qui déclenchent Caféine"
 
-#: prefs.js:361
+#: prefs.js:365
 msgid "Add Application"
 msgstr "Ajouter une application"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr "Général"
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr "Applications"
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr "Nouvel accélérateur…"
 
@@ -123,8 +135,11 @@ msgid "Application list"
 msgstr "Liste des applications"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:13
-msgid "A list of strings, each containing an application id (desktop file name)"
-msgstr "Liste de chaînes, chacune contenant l’id d’une application (nom de fichier desktop)"
+msgid ""
+"A list of strings, each containing an application id (desktop file name)"
+msgstr ""
+"Liste de chaînes, chacune contenant l’id d’une application (nom de fichier "
+"desktop)"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:17
 msgid "Store caffeine user state"
@@ -165,11 +180,15 @@ msgstr "Suspendre/réactiver le Mode nuit si activé/désactivé"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "DEPRECATED. Pause/resume Night Light for defined applications only"
-msgstr "OBSOLÈTE. Suspendre/réactiver le Mode nuit pour les applications choisies uniquement"
+msgstr ""
+"OBSOLÈTE. Suspendre/réactiver le Mode nuit pour les applications choisies "
+"uniquement"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
 msgid "Pause/resume Night Light for defined application when enabled/disabled"
-msgstr "Suspendre/réactiver le Mode nuit pour les applications choisies si activé/désactivé"
+msgstr ""
+"Suspendre/réactiver le Mode nuit pour les applications choisies si activé/"
+"désactivé"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Night Light control mode"
@@ -177,7 +196,8 @@ msgstr "Mode de contrôle du Mode nuit"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Set the way Caffeine interacts with the Night light setting."
-msgstr "Définir la manière dont Caféine interagit avec les réglages du Mode nuit."
+msgstr ""
+"Définir la manière dont Caféine interagit avec les réglages du Mode nuit."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Shortcut to toggle Caffeine."

--- a/caffeine@patapon.info/locale/hu/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/hu/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 01:39+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2018-06-22 21:22+0200\n"
 "Last-Translator: Kardos László <lacesz@NOSPAM@ox dot io>\n"
 "Language-Team: \n"
@@ -12,109 +12,118 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: extension.js:304
+#: extension.js:310
 #, fuzzy
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr "Az automatikus felfüggesztés és a képernyővédő letiltva"
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "Az automatikus felfüggesztés és a képernyővédő letiltva"
 
-#: extension.js:310
+#: extension.js:316
 #, fuzzy
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr "Az automatikus felfüggesztés és a képernyővédő engedélyezve"
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "Az automatikus felfüggesztés és a képernyővédő engedélyezve"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Show status indicator in top panel"
 msgstr "Indikátor megjelenítése a panelen"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "Indikátor megjelenítése a panelen"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Notifications"
 msgstr "Értesítések mutatása"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr "Értesítések mutatásának engedélyezése/tiltása"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr ""
 
-#: prefs.js:144
+#: prefs.js:145
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "Állapot visszaállítása újraindítás közben"
 
-#: prefs.js:147
+#: prefs.js:148
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Engedélyezés, ha teljes képernyős alkalmazás fut"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: prefs.js:150
+#: prefs.js:151
 #, fuzzy
 msgid "Pause and resume Night Light"
 msgstr "Értesítések mutatásának engedélyezése/tiltása"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr ""
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#, fuzzy
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr "Értesítések mutatásának engedélyezése/tiltása"
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr ""
 
-#: prefs.js:361
+#: prefs.js:365
 #, fuzzy
 msgid "Add Application"
 msgstr "Alkalmazás hozzáadás"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr ""
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr ""
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/it_IT/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/it_IT/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 01:39+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2022-05-09 16:53+0200\n"
 "Last-Translator: Simone Esposito <simoespo159@gmail.com>\n"
 "Language-Team: Giuseppe Pignataro (Fastbyte01) <rogepix@gmail.com>\n"
@@ -17,109 +17,118 @@ msgstr ""
 "X-Generator: Poedit 2.0.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:304
+#: extension.js:310
 #, fuzzy
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr "Auto sospensione e screensaver disabilitato"
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "Auto sospensione e screensaver disabilitato"
 
-#: extension.js:310
+#: extension.js:316
 #, fuzzy
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr "Auto sospensione e screensaver abilitato"
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "Auto sospensione e screensaver abilitato"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Show status indicator in top panel"
 msgstr "Mostra indicatore nel pannello in alto"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "Mostra indicatore nel pannello in alto"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Notifications"
 msgstr "Mostra notifiche"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr "Mostra notifiche quando abilitato/disabilitato"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr "Ricorda stato"
 
-#: prefs.js:144
+#: prefs.js:145
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "Ripristina lo stato dopo i riavvii"
 
-#: prefs.js:147
+#: prefs.js:148
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Abilita quando è avviata una applicazione a schermo intero"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "Abilita automaticamente quando un'app entra in modalità schermo intero"
 
-#: prefs.js:150
+#: prefs.js:151
 #, fuzzy
 msgid "Pause and resume Night Light"
 msgstr "Mostra notifiche quando abilitato/disabilitato"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Attiva la modalità notturna insieme allo stato di caffeine"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr "Mai"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr "Sempre"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr "Per le applicazioni in elenco"
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#, fuzzy
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr "Mostra notifiche quando abilitato/disabilitato"
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr "Applicazioni che abilitano caffeine"
 
-#: prefs.js:361
+#: prefs.js:365
 #, fuzzy
 msgid "Add Application"
 msgstr "Aggiungi applicazione"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr "Generali"
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr "Applicazioni"
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/ja/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/ja/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 01:39+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2017-05-05 22:28+0900\n"
 "Last-Translator: Jean-Philippe Braun <eon@patapon.info>\n"
 "Language-Team: French\n"
@@ -17,107 +17,115 @@ msgstr ""
 "X-Generator: Poedit 2.0.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:304
+#: extension.js:310
 #, fuzzy
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr "自動サスペンドを無効にしました"
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "自動サスペンドを無効にしました"
 
-#: extension.js:310
+#: extension.js:316
 #, fuzzy
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr "自動サスペンドを有効にしました"
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "自動サスペンドを有効にしました"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Show status indicator in top panel"
 msgstr "Caffeine をトップバーに表示する"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "Caffeine をトップバーに表示する"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Notifications"
 msgstr "通知を有効にする"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr ""
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr ""
 
-#: prefs.js:144
+#: prefs.js:145
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "再起動後も状態を維持する"
 
-#: prefs.js:147
+#: prefs.js:148
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "フルスクリーンアプリケーション実行時に有効にする"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Pause and resume Night Light"
 msgstr ""
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr ""
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr ""
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr ""
 
-#: prefs.js:361
+#: prefs.js:365
 #, fuzzy
 msgid "Add Application"
 msgstr "アプリケーションを追加"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr ""
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr ""
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/ko/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/ko/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-10 09:19+0200\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2022-09-10 10:53+0900\n"
 "Last-Translator: kuroehanako <kmj10727@gmail.com>\n"
 "Language-Team: \n"
@@ -15,103 +15,112 @@ msgstr ""
 "X-Poedit-Basepath: ../../gnome-shell-extension-caffeine-master\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: extension.js:304
+#: extension.js:310
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr ""
 "자동 대기 모드 진입 및 화면 보호기가 비활성화되었습니다. 야간 모드를 멈춥니"
 "다."
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "자동 대기 모드 진입 및 화면 보호기가 비활성화됨"
 
-#: extension.js:310
+#: extension.js:316
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr ""
 "자동 대기 모드 진입 및 화면 보호기가 활성화되었습니다. 야간 모드를 다시 켭니"
 "다."
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "자동 대기 모드 진입 및 화면 보호기가 활성화됨"
 
-#: prefs.js:138
+#: prefs.js:139
 msgid "Show status indicator in top panel"
 msgstr "상단 패널에 인디케이터 표시"
 
-#: prefs.js:138
+#: prefs.js:139
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "카페인 아이콘을 상단에 표시할지 결정합니다."
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Notifications"
 msgstr "알림"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr "카페인을 켜고 끌 때마다 알림을 표시합니다."
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr "상태 기억하기"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember the last state across sessions and reboots"
 msgstr "세션을 바꾸거나 다시 시작할 때 마지막 상태를 기억합니다."
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Enable for fullscreen apps"
 msgstr "전체 화면 프로그램에서 활성화"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "전체 화면 모드에 진입한 프로그램을 사용할 시 자동으로 활성화합니다."
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Pause and resume Night Light"
 msgstr "야간 모드를 멈추거나 다시 켜기"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "카페인의 상태에 맞춰 야간 모드를 제어합니다."
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr "안 함"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr "항상"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr "목록에 있는 프로그램만"
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#, fuzzy
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr "카페인을 켜고 끌 때마다 알림을 표시합니다."
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr "카페인을 제어할 프로그램"
 
-#: prefs.js:361
+#: prefs.js:365
 msgid "Add Application"
 msgstr "프로그램 추가"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr "일반"
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr "프로그램"
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/nl/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/nl/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 01:39+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2021-07-08 13:32+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch\n"
@@ -17,106 +17,115 @@ msgstr ""
 "X-Generator: Poedit 2.2.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:304
+#: extension.js:310
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr ""
 "Automatisch in slaapstand zetten, schermbeveiliging en nachtlicht zijn "
 "uitgeschakeld."
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr ""
 "Automatisch in slaapstand zetten en schermbeveiliging zijn uitgeschakeld"
 
-#: extension.js:310
+#: extension.js:316
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr ""
 "Automatisch in slaapstand zetten, schermbeveiliging en nachtlicht zijn "
 "ingeschakeld."
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr ""
 "Automatisch in slaapstand zetten en schermbeveiliging zijn ingeschakeld"
 
-#: prefs.js:138
+#: prefs.js:139
 msgid "Show status indicator in top panel"
 msgstr "Indicator tonen op bovenbalk"
 
-#: prefs.js:138
+#: prefs.js:139
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "Toon of verberg het Caffeine-pictogram op de bovenbalk"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Notifications"
 msgstr "Meldingen"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr "Toon meldingen als Caffeine wordt in- of uitgeschakeld"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr "Status onthouden"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember the last state across sessions and reboots"
 msgstr "Herstel de recentste status na wisselen van sessie en herstarten"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Enable for fullscreen apps"
 msgstr "Inschakelen bij beeldvullende toepassingen"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 "Schakel automatisch in als een toepassing de beeldvullende modus gebruikt"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Pause and resume Night Light"
 msgstr "Nachtlicht onderbreken en hervatten"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Schakel nachtlicht tegelijk met Caffeine in/uit"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr "Nooit"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr "Altijd"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr "Bij toepassingen op de lijst"
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#, fuzzy
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr "Toon meldingen als Caffeine wordt in- of uitgeschakeld"
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr "Toepassingen die Caffeine in-/uitschakelen"
 
-#: prefs.js:361
+#: prefs.js:365
 msgid "Add Application"
 msgstr "Toepassing toevoegen"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr "Algemeen"
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr "Toepassingen"
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/pl/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/pl/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 01:39+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2016-10-02 17:24+0100\n"
 "Last-Translator: Piotr Wittchen <piotr@wittchen.biz.pl>\n"
 "Language-Team: Polish\n"
@@ -17,106 +17,114 @@ msgstr ""
 "X-Generator: Vim\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:304
+#: extension.js:310
 #, fuzzy
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr "Automatycze wstrzymywanie i wygaszacz ekranu wyłączone"
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "Automatycze wstrzymywanie i wygaszacz ekranu wyłączone"
 
-#: extension.js:310
+#: extension.js:316
 #, fuzzy
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr "Automatyczne wstrzymywanie i wygaszacz ekranu włączone"
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "Automatyczne wstrzymywanie i wygaszacz ekranu włączone"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Show status indicator in top panel"
 msgstr "Pokazuj Caffeine w górnym panelu"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "Pokazuj Caffeine w górnym panelu"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Notifications"
 msgstr "Włącz notyfikacje"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr ""
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr ""
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember the last state across sessions and reboots"
 msgstr ""
 
-#: prefs.js:147
+#: prefs.js:148
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Włącz kiedy aplikacja jest uruchomiona w trybie pełnoekranowym"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Pause and resume Night Light"
 msgstr ""
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr ""
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr ""
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr ""
 
-#: prefs.js:361
+#: prefs.js:365
 #, fuzzy
 msgid "Add Application"
 msgstr "Dodaj aplikację"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr ""
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr ""
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/pt_BR/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/pt_BR/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 01:39+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2020-02-25 20:16-0300\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
 "Language-Team: Brazilian Portuguese <gnome-pt_br-list@gnome.org>\n"
@@ -22,109 +22,118 @@ msgstr ""
 "X-Generator: Gtranslator 3.32.0\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:304
+#: extension.js:310
 #, fuzzy
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr "Suspensão e proteção de tela automáticas desativadas"
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "Suspensão e proteção de tela automáticas desativadas"
 
-#: extension.js:310
+#: extension.js:316
 #, fuzzy
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr "Suspensão e proteção de tela automáticas ativadas"
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "Suspensão e proteção de tela automáticas ativadas"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Show status indicator in top panel"
 msgstr "Mostrar o indicador no painel superior"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "Mostrar o indicador no painel superior"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Notifications"
 msgstr "Mostrar notificações"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr "Mostra notificações quando ativado/desativado"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr ""
 
-#: prefs.js:144
+#: prefs.js:145
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "Restaurar estado entre reinicializações"
 
-#: prefs.js:147
+#: prefs.js:148
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Ativar enquanto um aplicativo em tela cheia estiver executando"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: prefs.js:150
+#: prefs.js:151
 #, fuzzy
 msgid "Pause and resume Night Light"
 msgstr "Mostra notificações quando ativado/desativado"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr ""
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#, fuzzy
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr "Mostra notificações quando ativado/desativado"
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr ""
 
-#: prefs.js:361
+#: prefs.js:365
 #, fuzzy
 msgid "Add Application"
 msgstr "Adicionar aplicativo"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr ""
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr ""
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/pt_PT/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/pt_PT/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 01:39+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2016-12-02 10:01+0100\n"
 "Last-Translator: Steeven Lopes <steevenlopes@outlook.com>\n"
 "Language-Team: Portuguese\n"
@@ -17,106 +17,114 @@ msgstr ""
 "X-Generator: Poedit 1.6.10\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:304
+#: extension.js:310
 #, fuzzy
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr "Suspensão automática e protecção de ecrã desativado"
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "Suspensão automática e protecção de ecrã desativado"
 
-#: extension.js:310
+#: extension.js:316
 #, fuzzy
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr "Suspensão automática e protecção de ecrã ativado"
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "Suspensão automática e protecção de ecrã ativado"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Show status indicator in top panel"
 msgstr "Mostrar Caffeine no painel superior"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "Mostrar Caffeine no painel superior"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Notifications"
 msgstr "Ativar notificações"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr ""
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr ""
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember the last state across sessions and reboots"
 msgstr ""
 
-#: prefs.js:147
+#: prefs.js:148
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Ativar quando uma aplicação estiver a correr no modo ecrã inteiro"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Pause and resume Night Light"
 msgstr ""
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr ""
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr ""
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr ""
 
-#: prefs.js:361
+#: prefs.js:365
 #, fuzzy
 msgid "Add Application"
 msgstr "Adicionar aplicação"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr ""
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr ""
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/ru/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/ru/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 01:39+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2022-02-08 13:07+0300\n"
 "Last-Translator: Aleksandr Melman <Alexmelman88@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -17,104 +17,113 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:304
+#: extension.js:310
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr ""
 "Автоматический режим ожидания и заставка отключены. Ночная подсветка "
 "приостановлена."
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "Автоматический режим ожидания и заставка отключены"
 
-#: extension.js:310
+#: extension.js:316
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr ""
 "Автоматический режим ожидания и заставка включены. Ночная подсветка "
 "возобновлена."
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "Автоматический режим ожидания и заставка включены"
 
-#: prefs.js:138
+#: prefs.js:139
 msgid "Show status indicator in top panel"
 msgstr "Показывать индикатор состояния на верхней панели"
 
-#: prefs.js:138
+#: prefs.js:139
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "Включить или отключить значок Кофеина на верхней панели"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Notifications"
 msgstr "Уведомления"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr "Включить уведомления о включении или отключении Кофеина"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr "Запомнить состояние"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember the last state across sessions and reboots"
 msgstr "Запомнить последнее состояние после смены сеанса и перезагрузки"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Enable for fullscreen apps"
 msgstr "Включить для полноэкранных приложений"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 "Автоматически включать, когда приложение переходит в полноэкранный режим"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Pause and resume Night Light"
 msgstr "Приостановка и возобновление ночной подсветки"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Переключение ночной подсветки вместе с состоянием Кофеина"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr "Никогда"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr "Всегда"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr "Для приложений из списка"
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#, fuzzy
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr "Включить уведомления о включении или отключении Кофеина"
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr "Приложения, запускающие действие Кофеина"
 
-#: prefs.js:361
+#: prefs.js:365
 msgid "Add Application"
 msgstr "Добавить приложение"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr "Общие"
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr "Приложения"
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/sk/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/sk/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 01:39+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2015-01-16 10:24+0100\n"
 "Last-Translator: Dušan Kazik <prescott66@gmail.com>\n"
 "Language-Team: Slovak\n"
@@ -17,106 +17,114 @@ msgstr ""
 "X-Generator: Poedit 1.7.3\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:304
+#: extension.js:310
 #, fuzzy
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr "Automatické uspanie a šetrič obrazovky sú zakázané"
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "Automatické uspanie a šetrič obrazovky sú zakázané"
 
-#: extension.js:310
+#: extension.js:316
 #, fuzzy
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr "Automatické uspanie a šetrič obrazovky sú povolené"
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "Automatické uspanie a šetrič obrazovky sú povolené"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Show status indicator in top panel"
 msgstr "Zobraziť Caffeine v hornej lište"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "Zobraziť Caffeine v hornej lište"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Notifications"
 msgstr "Povoliť oznámenia"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr ""
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr ""
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember the last state across sessions and reboots"
 msgstr ""
 
-#: prefs.js:147
+#: prefs.js:148
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Povoliť, keď je spustená aplikácia v režime na celú obrazovku"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Pause and resume Night Light"
 msgstr ""
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr ""
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr ""
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr ""
 
-#: prefs.js:361
+#: prefs.js:365
 #, fuzzy
 msgid "Add Application"
 msgstr "Pridať aplikáciu"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr ""
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr ""
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/sv/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/sv/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 01:39+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2018-04-04 20:35+0200\n"
 "Last-Translator: Morgan Antonsson <morgan.antonsson@gmail.com>\n"
 "Language-Team: \n"
@@ -11,109 +11,118 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: extension.js:304
+#: extension.js:310
 #, fuzzy
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr "Automatiskt vänteläge och skärmsläckare inaktiverade"
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "Automatiskt vänteläge och skärmsläckare inaktiverade"
 
-#: extension.js:310
+#: extension.js:316
 #, fuzzy
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr "Automatiskt vänteläge och skärmsläckare aktiverade"
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "Automatiskt vänteläge och skärmsläckare aktiverade"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Show status indicator in top panel"
 msgstr "Visa indikator i panelen"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "Visa indikator i panelen"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Notifications"
 msgstr "Visa notifieringar"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr "Visa notifieringar vid aktivering/inaktivering"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr ""
 
-#: prefs.js:144
+#: prefs.js:145
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "Återställ tillstånd efter omstart"
 
-#: prefs.js:147
+#: prefs.js:148
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Aktivera när ett program använder helskärmsläget"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: prefs.js:150
+#: prefs.js:151
 #, fuzzy
 msgid "Pause and resume Night Light"
 msgstr "Visa notifieringar vid aktivering/inaktivering"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr ""
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#, fuzzy
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr "Visa notifieringar vid aktivering/inaktivering"
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr ""
 
-#: prefs.js:361
+#: prefs.js:365
 #, fuzzy
 msgid "Add Application"
 msgstr "Lägg till program"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr ""
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr ""
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/tr/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/tr/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 01:39+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2019-03-21 06:48+0300\n"
 "Last-Translator: Serdar Sağlam <teknomobil@yandex.com>\n"
 "Language-Team: Turkish <gnome-turk@gnome.org>\n"
@@ -18,109 +18,118 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Generator: Gtranslator 3.32.0\n"
 
-#: extension.js:304
+#: extension.js:310
 #, fuzzy
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr "Ekran koruyucu ve otomatik karartma kapalı"
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "Ekran koruyucu ve otomatik karartma kapalı"
 
-#: extension.js:310
+#: extension.js:316
 #, fuzzy
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr "Ekran koruyucu ve otomatik karartma açık"
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "Ekran koruyucu ve otomatik karartma açık"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Show status indicator in top panel"
 msgstr "Göstergeyi üst panelde göster"
 
-#: prefs.js:138
+#: prefs.js:139
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "Göstergeyi üst panelde göster"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Notifications"
 msgstr "Bildirimleri göster"
 
-#: prefs.js:141
+#: prefs.js:142
 #, fuzzy
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr "Aktif/Pasif olduğunda bildirimleri göster"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr ""
 
-#: prefs.js:144
+#: prefs.js:145
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "Yeniden başlatma arasında durumu geri yükle"
 
-#: prefs.js:147
+#: prefs.js:148
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Tam ekran uygulama çalıştırıldığı zaman aktif olacaktır"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: prefs.js:150
+#: prefs.js:151
 #, fuzzy
 msgid "Pause and resume Night Light"
 msgstr "Aktif/Pasif olduğunda bildirimleri göster"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr ""
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr ""
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#, fuzzy
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr "Aktif/Pasif olduğunda bildirimleri göster"
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr ""
 
-#: prefs.js:361
+#: prefs.js:365
 #, fuzzy
 msgid "Add Application"
 msgstr "Uygulama ekle"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr ""
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr ""
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/zh_CN/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/zh_CN/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-30 23:20+0300\n"
+"POT-Creation-Date: 2022-10-11 08:31+0700\n"
 "PO-Revision-Date: 2022-06-30 11:54-0400\n"
 "Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <debian-l10n-chinese@lists.debian.org>\n"
@@ -17,99 +17,108 @@ msgstr ""
 "X-Generator: Poedit 3.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:304
+#: extension.js:310
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr "自动挂起与屏幕保护程序已禁用。夜灯已暂停。"
 
-#: extension.js:306
+#: extension.js:312
 msgid "Auto suspend and screensaver disabled"
 msgstr "自动挂起与屏幕保护程序已禁用"
 
-#: extension.js:310
+#: extension.js:316
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr "自动挂起与屏幕保护程序已启用。夜灯已恢复。"
 
-#: extension.js:312
+#: extension.js:318
 msgid "Auto suspend and screensaver enabled"
 msgstr "自动挂起与屏幕保护程序已启用"
 
-#: prefs.js:138
+#: prefs.js:139
 msgid "Show status indicator in top panel"
 msgstr "在顶部面板显示状态指示器"
 
-#: prefs.js:138
+#: prefs.js:139
 msgid "Enable or disable the Caffeine icon in the top panel"
 msgstr "在顶部面板启用或禁用 Caffeine 图标"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Notifications"
 msgstr "通知"
 
-#: prefs.js:141
+#: prefs.js:142
 msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr "在 Caffeine 被启用或禁用时显示通知"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember state"
 msgstr "记住状态"
 
-#: prefs.js:144
+#: prefs.js:145
 msgid "Remember the last state across sessions and reboots"
 msgstr "跨会话和重启记住上一次的状态"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Enable for fullscreen apps"
 msgstr "为全屏程序启用"
 
-#: prefs.js:147
+#: prefs.js:148
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "在有应用进入全屏模式时自动启用"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Pause and resume Night Light"
 msgstr "暂停和恢复夜灯"
 
-#: prefs.js:150
+#: prefs.js:151
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "随 Caffeine 的状态切换夜灯"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Never"
 msgstr "从不"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "Always"
 msgstr "总是"
 
-#: prefs.js:152
+#: prefs.js:153
 msgid "For apps on list"
 msgstr "用于列表上的应用"
 
-#: prefs.js:157 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: prefs.js:158 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Toggle shortcut"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:158
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: prefs.js:189
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+msgid "Allow screen blank"
+msgstr ""
+
+#: prefs.js:161 schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#, fuzzy
+msgid "Allow turning off screen when Caffeine is enabled"
+msgstr "在 Caffeine 被启用或禁用时显示通知"
+
+#: prefs.js:193
 msgid "Apps that trigger Caffeine"
 msgstr "触发 Caffeine 的应用"
 
-#: prefs.js:361
+#: prefs.js:365
 msgid "Add Application"
 msgstr "添加应用程序"
 
-#: prefs.js:399
+#: prefs.js:403
 msgid "General"
 msgstr "常规"
 
-#: prefs.js:402
+#: prefs.js:406
 msgid "Apps"
 msgstr "应用"
 
-#: prefs.js:426 prefs.js:437
+#: prefs.js:430 prefs.js:441
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/prefs.js
+++ b/caffeine@patapon.info/prefs.js
@@ -18,6 +18,7 @@ const SettingsKey = {
     RESTORE: 'restore-state',
     NIGHT_LIGHT: 'nightlight-control',
     TOGGLE_SHORTCUT: 'toggle-shortcut',
+    SCREEN_BLANK: 'screen-blank',
 };
 
 const SettingListBoxRow = GObject.registerClass({
@@ -156,6 +157,9 @@ const SettingsPane = GObject.registerClass(
 
             const _toggleShortcut = new SettingListBoxRow(_('Toggle shortcut'), _('Use Backspace to clear'), SettingsKey.TOGGLE_SHORTCUT, 'shortcut');
             _listBox.append(_toggleShortcut);
+
+            const _screenBlank = new SettingListBoxRow(_('Allow screen blank'), _('Allow turning off screen when Caffeine is enabled'), SettingsKey.SCREEN_BLANK);
+            _listBox.append(_screenBlank);
         }
 
         _rowActivated(widget, row) {

--- a/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
+++ b/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
@@ -57,5 +57,10 @@
         <summary>Toggle shortcut</summary>
         <description>Shortcut to toggle Caffeine.</description>
     </key>
+    <key type="b" name="screen-blank">
+        <default>false</default>
+        <summary>Allow screen blank</summary>
+        <description>Allow turning off screen when Caffeine is enabled</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Note: Remember State should also enabled

Implements: https://github.com/eonpatapon/gnome-shell-extension-caffeine/issues/188