### PR TITLE
Add setting to change duration timer

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -205,7 +205,7 @@ class CaffeineToggle extends QuickSettings.QuickMenuToggle {
             if(timer[0] === 0) {
                 label = _('Infinite');
             } else {
-                label = timer[durationIndex] + ":00";
+                label = parseInt(timer[durationIndex]) + 'm';
             }
             if (!label)
                 continue;

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -213,7 +213,7 @@ class CaffeineToggle extends QuickSettings.QuickMenuToggle {
             const item = new PopupMenu.PopupImageMenuItem(label, icon);
             item.connect('activate',() => (this._checkTimer(timer[durationIndex])));
             this._timerItems.set(timer[durationIndex], item);
-            this._itemsSection.addMenuItem(item); 
+            this._itemsSection.addMenuItem(item);
         }
         this.menuEnabled = TIMERS.length > 2;
     }

--- a/caffeine@patapon.info/preferences/generalPage.js
+++ b/caffeine@patapon.info/preferences/generalPage.js
@@ -217,7 +217,7 @@ class Caffeine_GeneralPage extends Adw.PreferencesPage {
         this.timerOptionRow.set_subtitle(_("Set to ") + TIMERS_DURATION[value] + _(" minutes"));
         if (durationIndex !== value) {
             this._settings.set_int(this._settingsKey.DURATION_TIMER_INDEX, value);
-        }          
+        }
     }
 
     _resetShortcut() {

--- a/caffeine@patapon.info/preferences/generalPage.js
+++ b/caffeine@patapon.info/preferences/generalPage.js
@@ -32,6 +32,14 @@ const ComboBoxChoices = {
     FOR_APPS: _("For apps on list"),
 };
 
+const TIMERS_DURATION = [
+    "05, 10, 30",
+    "10, 20, 45",
+    "15, 30, 60",
+    "20, 40, 75",
+    "30, 50, 80"
+];
+
 var GeneralPage = GObject.registerClass(
 class Caffeine_GeneralPage extends Adw.PreferencesPage {
     _init(settings, settingsKey) {
@@ -104,6 +112,48 @@ class Caffeine_GeneralPage extends Adw.PreferencesPage {
         behaviorGroup.add(allowBlankScreenRow);
         this.add(behaviorGroup);
 
+        // Timer group
+        // --------------
+        let timerGroup = new Adw.PreferencesGroup({
+            title: _("Timer")
+        });
+
+        const durationIndex = this._settings.get_int(this._settingsKey.DURATION_TIMER_INDEX);
+        this.timerOptionRow = new Adw.ActionRow({
+            title: _("Duration"),
+            activatable: true
+        });
+
+        let adjustSliderTimer = new Gtk.Adjustment({
+            lower: 0,
+            upper: 4,
+            step_increment: 0.1,
+            page_increment: 1,      
+            value: durationIndex
+        });
+        this._updateTimerDuration(durationIndex);
+
+        let sliderTimer = new Gtk.Scale({
+            valign: 'center',
+            hexpand: true,
+            width_request: '200px',
+            round_digits: false,
+            draw_value: false,
+            orientation: 'horizontal',
+            digits: 0,
+            adjustment: adjustSliderTimer
+        });
+        sliderTimer.add_mark(0, Gtk.PositionType.BOTTOM, null);
+        sliderTimer.add_mark(1, Gtk.PositionType.BOTTOM, null);
+        sliderTimer.add_mark(2, Gtk.PositionType.BOTTOM, null);
+        sliderTimer.add_mark(3, Gtk.PositionType.BOTTOM, null);
+        sliderTimer.add_mark(4, Gtk.PositionType.BOTTOM, null);
+        this.timerOptionRow.add_suffix(sliderTimer);
+
+        // Add elements
+        timerGroup.add(this.timerOptionRow);
+        this.add(timerGroup);
+
         // Shortcut group
         // --------------
         let deleteShortcutButton = new Gtk.Button({
@@ -150,6 +200,8 @@ class Caffeine_GeneralPage extends Adw.PreferencesPage {
         allowBlankScreenRow.connect('notify::selected', (widget) => {
             this._settings.set_enum(this._settingsKey.SCREEN_BLANK, widget.selected);
         });
+        sliderTimer.connect('change-value',
+            (widget) => this._updateTimerDuration(widget.get_value()));
         deleteShortcutButton.connect('clicked', this._resetShortcut.bind(this));
         this._settings.connect(`changed::${this._settingsKey.TOGGLE_SHORTCUT}`, () => {
             if( this.shortcutKeyBoard.isAcceleratorSet() ) {
@@ -158,6 +210,14 @@ class Caffeine_GeneralPage extends Adw.PreferencesPage {
                 deleteShortcutButton.visible = false;
             }
         });
+    }
+
+    _updateTimerDuration(value) {
+        const durationIndex = this._settings.get_int(this._settingsKey.DURATION_TIMER_INDEX);
+        this.timerOptionRow.set_subtitle(_("Set to ") + TIMERS_DURATION[value] + _(" minutes"));
+        if (durationIndex !== value) {
+            this._settings.set_int(this._settingsKey.DURATION_TIMER_INDEX, value);
+        }          
     }
 
     _resetShortcut() {

--- a/caffeine@patapon.info/preferences/generalPage.js
+++ b/caffeine@patapon.info/preferences/generalPage.js
@@ -120,7 +120,7 @@ class Caffeine_GeneralPage extends Adw.PreferencesPage {
 
         const durationIndex = this._settings.get_int(this._settingsKey.DURATION_TIMER_INDEX);
         this.timerOptionRow = new Adw.ActionRow({
-            title: _("Duration"),
+            title: _("Durations"),
             activatable: true
         });
 

--- a/caffeine@patapon.info/prefs.js
+++ b/caffeine@patapon.info/prefs.js
@@ -32,6 +32,7 @@ const SettingsKey = {
     SHOW_INDICATOR: 'show-indicator',
     SHOW_NOTIFICATIONS: 'show-notifications',
     SHOW_TIMER: 'show-timer',
+    DURATION_TIMER_INDEX: 'duration-timer',
     FULLSCREEN: 'enable-fullscreen',
     RESTORE: 'restore-state',
     NIGHT_LIGHT: 'nightlight-control',

--- a/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
+++ b/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
@@ -42,6 +42,11 @@
         <summary>Specify time (minutes) for the timer countdown</summary>
         <description>Specify time (minutes) for the timer countdown</description>
     </key>
+    <key type="i" name="duration-timer">
+        <default>2</default>
+        <summary>Specify index of duration range for the timer</summary>
+        <description>Specify index of duration range for the timer</description>
+    </key>
     <key type="b" name="restore-state">
         <default>false</default>
         <summary>Restore caffeine state</summary>
@@ -88,11 +93,11 @@
         <description>Shortcut to toggle Caffeine.</description>
     </key>
     <key type="i" name="prefs-default-width">
-      <default>700</default>
+      <default>570</default>
       <summary>Default width for the preferences window</summary>
     </key>
     <key type="i" name="prefs-default-height">
-      <default>600</default>
+      <default>590</default>
       <summary>Default height for the preferences window</summary>
     </key>
     <key type="i" name="indicator-position">


### PR DESCRIPTION
Add a new setting to tweak the duration timer range in preferences.
Default is set to 15, 30 and 60 minutes as discussed in  [#224](https://github.com/eonpatapon/gnome-shell-extension-caffeine/issues/224).

![image](https://user-images.githubusercontent.com/83842133/219122391-d8b22d57-f0d3-4186-a969-0931bc1344b1.png)
