### PR TITLE
Fix bad call of _toggleWorkspace()

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -896,7 +896,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
             if(type === 0) {
                 // Add 100 ms delay to handle window detection
                 this._timeWorkspaceAdd = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
-                    this._toggleWorkspace.bind(this);
+                    this._toggleWorkspace();
                     this._timeWorkspaceAdd = null;
                     return GLib.SOURCE_REMOVE;
                 });
@@ -909,7 +909,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
             if(type === 0) {
                 // Add 100 ms delay to handle window detection
                 this._timeWorkspaceRemove = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
-                    this._toggleWorkspace.bind(this);
+                    this._toggleWorkspace();
                     this._timeWorkspaceRemove = null;
                     return GLib.SOURCE_REMOVE;
                 });


### PR DESCRIPTION
Apologies, I haven't test enough the extension since switched to `GLib.timeout_add`  ([commit #223](https://github.com/eonpatapon/gnome-shell-extension-caffeine/pull/223/commits/af018660502511c1997375037211ac208b73c0b0)). I just figure out that there is a bug with app triggering in "active workspace" mode: Caffeine isn't triggered when add/remove app. This commit fix the issue.