### PR TITLE
Fix "Status indicator Position" capital and update translation strings

### DIFF
--- a/caffeine@patapon.info/locale/cs/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/cs/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2022-04-13 15:18+0200\n"
 "Last-Translator: Daniel Rusek <mail@asciiwolf.com>\n"
 "Language-Team: Czech\n"
@@ -17,28 +17,28 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:99
+#: extension.js:102
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:733
+#: extension.js:755
 #, fuzzy
 msgid "Night Light paused"
 msgstr "Noční světlo"
 
-#: extension.js:738
+#: extension.js:760
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:740
+#: extension.js:762
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "Noční světlo obnoveno"
@@ -125,7 +125,7 @@ msgstr "Povolit upozornění, když je Caffeine povoleno nebo zakázáno"
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "Zobrazit indikátor stavu v horní liště"
 
 #: preferences/displayPage.js:99
@@ -136,62 +136,78 @@ msgstr ""
 msgid "For apps on list"
 msgstr "Pro aplikace na seznamu"
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr "Obecné"
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 msgid "Enable for fullscreen apps"
 msgstr "Povolit pro celoobrazovkové aplikace"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "Automaticky povolit, když aplikace přejde do režimu celé obrazovky"
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr "Pamatovat stav"
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 msgid "Remember the last state across sessions and reboots"
 msgstr "Pamatovat si poslední stav mezi sezeními a restarty"
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 msgid "Pause and resume Night Light"
 msgstr "Pozastavit a obnovit Noční světlo"
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Přepne noční světlo spolu se stavem Caffeine"
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Povolit upozornění, když je Caffeine povoleno nebo zakázáno"
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr ""
 
@@ -223,85 +239,90 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+msgid "Specify index of duration range for the timer"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Restore caffeine state"
 msgstr "Obnovit stav caffeine"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr "Zobrazit indikátor"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show the indicator on the top panel"
 msgstr "Zobrazit indikátor v horní liště"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show notifications"
 msgstr "Zobrazit upozornění"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr "Zobrazit upozornění, když je povoleno/zakázáno"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Zobrazit upozornění, když je povoleno/zakázáno"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "Povolit, když je spuštěná aplikace v režimu celé obrazovky"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr "Režim řízení Nočního světla"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 "Nastavte způsob, kterým Caffeine interaguje s nastavením Nočního světla."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Povolit upozornění, když je Caffeine povoleno nebo zakázáno"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 #, fuzzy
 msgid "Trigger App control mode"
 msgstr "Režim řízení Nočního světla"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/de/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/de/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2021-04-09 21:31-0400\n"
 "Last-Translator: Felix Kaechele <felix@kaechele.ca>\n"
 "Language-Team: German\n"
@@ -17,29 +17,29 @@ msgstr ""
 "X-Generator: Poedit 2.4.2\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:99
+#: extension.js:102
 #, fuzzy
 msgid "Caffeine timer"
 msgstr "Caffeine schaltuhr"
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr "unendlich"
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr "Caffeine aktiviert"
 
-#: extension.js:733
+#: extension.js:755
 msgid "Night Light paused"
 msgstr "Nachtmodus pausiert"
 
-#: extension.js:738
+#: extension.js:760
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine aktiviert"
 
-#: extension.js:740
+#: extension.js:762
 msgid "Night Light resumed"
 msgstr "Nachtmodus fortgesetzt"
 
@@ -125,7 +125,7 @@ msgstr "Benachrichtigungen anzeigen, wenn aktiviert/deaktiviert"
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "Indikator-Icon in der oberen Leiste anzeigen"
 
 #: preferences/displayPage.js:99
@@ -136,62 +136,78 @@ msgstr ""
 msgid "For apps on list"
 msgstr "Für Apps auf Liste"
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr "Allgemein"
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 msgid "Enable for fullscreen apps"
 msgstr "Aktiviere für Vollbild Anwendungen"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "Automatisch aktivieren wenn Anwendung in den Vollbildmodus wechselt"
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr "Zustand wiederherstellen"
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 msgid "Remember the last state across sessions and reboots"
 msgstr "Nach einem Neustart den Zustand wiederherstellen"
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 msgid "Pause and resume Night Light"
 msgstr "Nachtmodus unterbrechen"
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Unterbricht den Nachtmodus wenn Caffeine aktiviert wird"
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Benachrichtigungen anzeigen, wenn aktiviert/deaktiviert"
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr ""
 
@@ -225,83 +241,88 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+msgid "Specify index of duration range for the timer"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Restore caffeine state"
 msgstr "Caffeines Zustand wiederherstellen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr "Indikator anzeigen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show the indicator on the top panel"
 msgstr "Caffeine-Indikator in der oberen Leiste anzeigen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show notifications"
 msgstr "Benachrichtigungen aktivieren"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr "Benachrichtigungen anzeigen, wenn aktiviert/deaktiviert"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Benachrichtigungen anzeigen, wenn aktiviert/deaktiviert"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "Aktivieren, sobald eine Anwendung im Vollbildmodus läuft"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Benachrichtigungen anzeigen, wenn aktiviert/deaktiviert"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/es/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/es/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2015-11-28 21:06-0300\n"
 "Last-Translator: Sergio D. Márquez <marquez.sergio.d@gmail.com>\n"
 "Language-Team: Spanish\n"
@@ -17,29 +17,29 @@ msgstr ""
 "X-Generator: Poedit 1.8.6\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:99
+#: extension.js:102
 #, fuzzy
 msgid "Caffeine timer"
 msgstr "Caffeine temporizador"
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr "Infinito"
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr "Caffeine activado"
 
-#: extension.js:733
+#: extension.js:755
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:738
+#: extension.js:760
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine activado"
 
-#: extension.js:740
+#: extension.js:762
 msgid "Night Light resumed"
 msgstr ""
 
@@ -129,7 +129,7 @@ msgstr "Mostrar notificaciones de habilitado/deshabilitado"
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "Mostrar Caffeine en el panel superior"
 
 #: preferences/displayPage.js:99
@@ -140,67 +140,83 @@ msgstr ""
 msgid "For apps on list"
 msgstr "Para aplicaciones en la lista"
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr ""
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr "Comportamiento"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Activar cuando una aplicación a pantalla completa esté en ejecución"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 "Activar automáticamente cuando una aplicación entra en modo de pantalla "
 "completa"
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr "Recordar estado"
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "Restablecer estado despues de reiniciar"
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 #, fuzzy
 msgid "Pause and resume Night Light"
 msgstr "Mostrar notificaciones de habilitado/deshabilitado"
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Mostrar notificaciones de habilitado/deshabilitado"
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 msgid "Shortcut"
 msgstr "Atajo"
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr ""
 
@@ -235,85 +251,90 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+msgid "Specify index of duration range for the timer"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Restore caffeine state"
 msgstr "Restablecer estado de Caffeine"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr "Mostrar indicador"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 #, fuzzy
 msgid "Show the indicator on the top panel"
 msgstr "Mostrar Caffeine en el panel superior"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 #, fuzzy
 msgid "Show notifications"
 msgstr "Activar las notificaciones"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr "Mostrar notificaciones de habilitado/deshabilitado"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Mostrar notificaciones de habilitado/deshabilitado"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "Activar cuando una aplicación a pantalla completa esté en ejecución"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Mostrar notificaciones de habilitado/deshabilitado"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2022-10-07 16:40+0200\n"
 "Last-Translator: Simon Elst <kirmaha@duck.com>\n"
 "Language-Team: French\n"
@@ -22,30 +22,30 @@ msgstr ""
 "X-Generator: Poedit 3.1.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:99
+#: extension.js:102
 #, fuzzy
 msgid "Caffeine timer"
 msgstr "Caffeine minuteur"
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr "Infini"
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr "Caféine est activé"
 
-#: extension.js:733
+#: extension.js:755
 #, fuzzy
 msgid "Night Light paused"
 msgstr "Mode nuit suspendu"
 
-#: extension.js:738
+#: extension.js:760
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caféine est activé"
 
-#: extension.js:740
+#: extension.js:762
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "Mode nuit réactivé"
@@ -132,7 +132,7 @@ msgstr "Activer les notifications quand Caféine est activé ou désactivé"
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "Position de l'icone"
 
 #: preferences/displayPage.js:99
@@ -143,66 +143,82 @@ msgstr "La position de l'icone dans la barre supérieure"
 msgid "For apps on list"
 msgstr "Pour les applications de la liste"
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr "Général"
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr "Comportement"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 msgid "Enable for fullscreen apps"
 msgstr "Activer pour les applications en plein écran"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 "Activer automatiquement lorsqu’une application entre en mode plein écran"
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr "Se souvenir de l’état"
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 msgid "Remember the last state across sessions and reboots"
 msgstr ""
 "Se souvenir du dernier état au-delà des changements de session et "
 "redémarrages"
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 msgid "Pause and resume Night Light"
 msgstr "Suspendre et réactiver le Mode nuit"
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Commute le Mode nuit en fonction de l’état de Caféine"
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr "Autoriser la mise en veille de l'écran seulement"
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Activer les notifications quand Caféine est activé ou désactivé"
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 #, fuzzy
 msgid "Shortcut"
 msgstr "Raccourci"
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr "Raccourci clavier"
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr "Utiliser Retour arrière pour effacer"
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr "Nouvel accélérateur…"
 
@@ -236,85 +252,91 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr "Durée du minuteur (en minutes)"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+#, fuzzy
+msgid "Specify index of duration range for the timer"
+msgstr "Durée du minuteur (en minutes)"
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Restore caffeine state"
 msgstr "Rétablir l’état utilisateur de Caféine"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr "Afficher l’indicateur"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show the indicator on the top panel"
 msgstr "Afficher Caféine dans la barre supérieure"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show notifications"
 msgstr "Afficher les notifications"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr "Afficher les notifications si activé/désactivé"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr "Afficher le minuteur"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Afficher le minuteur si activé/désactivé"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "Activer lorsqu’une application est en plein écran"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr "Contrôle du Mode nuit"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 "Définir la manière dont Caféine interagit avec les réglages du Mode nuit."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Activer les notifications quand Caféine est activé ou désactivé"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 #, fuzzy
 msgid "Trigger App control mode"
 msgstr "Contrôle du Mode nuit"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr "Raccourci pour commuter Caféine."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -190,11 +190,11 @@ msgstr "Activer les notifications quand Caféine est activé ou désactivé"
 
 #: preferences/generalPage.js:118
 msgid "Timer"
-msgstr ""
+msgstr "Minuteur"
 
 #: preferences/generalPage.js:123
 msgid "Durations"
-msgstr ""
+msgstr "Durées"
 
 #: preferences/generalPage.js:167
 #, fuzzy
@@ -212,7 +212,7 @@ msgstr "Utiliser Retour arrière pour effacer"
 
 #: preferences/generalPage.js:217
 msgid "Set to "
-msgstr ""
+msgstr "Réglé sur "
 
 #: preferences/generalPage.js:217
 msgid " minutes"
@@ -255,7 +255,7 @@ msgstr "Durée du minuteur (en minutes)"
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
 #, fuzzy
 msgid "Specify index of duration range for the timer"
-msgstr "Durée du minuteur (en minutes)"
+msgstr "Index de selection des durées du minuteur"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Restore caffeine state"
@@ -312,7 +312,7 @@ msgstr "Contrôle du Mode nuit"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
-msgstr ""
+msgstr "Sélection de la méthode de déclenchement par les applications"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
@@ -320,25 +320,25 @@ msgstr "Raccourci pour commuter Caféine."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
-msgstr ""
+msgstr "Largeur par défaut de la fenêtre de préférences"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
-msgstr ""
+msgstr "Hauteur par défaut de la fenêtre de préférences"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
-msgstr ""
+msgstr "Position relative de l’icône dans le menu indicator"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
-msgstr ""
+msgstr "Position réel de l’icône dans le menu indicator (comprend les icônes invisibles)"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
-msgstr ""
+msgstr "Index du dernier élément dans le menu indicator"
 
 #~ msgid "Auto suspend and screensaver disabled"
 #~ msgstr "Mise en veille et écran de veille désactivés"

--- a/caffeine@patapon.info/locale/hu/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/hu/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2018-06-22 21:22+0200\n"
 "Last-Translator: Kardos László <lacesz@NOSPAM@ox dot io>\n"
 "Language-Team: \n"
@@ -12,27 +12,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: extension.js:99
+#: extension.js:102
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:733
+#: extension.js:755
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:738
+#: extension.js:760
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:740
+#: extension.js:762
 msgid "Night Light resumed"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr "Értesítések mutatásának engedélyezése/tiltása"
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "Indikátor megjelenítése a panelen"
 
 #: preferences/displayPage.js:99
@@ -133,67 +133,83 @@ msgstr ""
 msgid "For apps on list"
 msgstr "A listán szereplő alkalmazásokhoz"
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr "Tábornok"
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Engedélyezés, ha teljes képernyős alkalmazás fut"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 "Automatikus engedélyezés, amikor egy alkalmazás teljes képernyős módba lép"
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr "Emlékezz állapotra"
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "Állapot visszaállítása újraindítás közben"
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 #, fuzzy
 msgid "Pause and resume Night Light"
 msgstr "Értesítések mutatásának engedélyezése/tiltása"
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Együtt kapcsolja az éjszakai fényt a koffein állapotával"
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Értesítések mutatásának engedélyezése/tiltása"
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 #, fuzzy
 msgid "Shortcut"
 msgstr "Parancsikon átváltása"
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr "Parancsikon átváltása"
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr "A törléshez használja a Backspace gombot"
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr ""
 
@@ -227,83 +243,88 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+msgid "Specify index of duration range for the timer"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Restore caffeine state"
 msgstr "Caffeine állapot visszaállítása"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr "Megjenelnítés az indikátoron"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show the indicator on the top panel"
 msgstr "Indikátor megjelenítése a panelen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show notifications"
 msgstr "Értesítések mutatása"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr "Értesítések mutatásának engedélyezése/tiltása"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Értesítések mutatásának engedélyezése/tiltása"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "Engedélyezés, ha teljes képernyős alkalmazás fut"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Értesítések mutatásának engedélyezése/tiltása"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/it_IT/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/it_IT/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2022-05-09 16:53+0200\n"
 "Last-Translator: Simone Esposito <simoespo159@gmail.com>\n"
 "Language-Team: Giuseppe Pignataro (Fastbyte01) <rogepix@gmail.com>\n"
@@ -17,29 +17,29 @@ msgstr ""
 "X-Generator: Poedit 2.0.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:99
+#: extension.js:102
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr "Infinito"
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr "Caffeine aktiviert"
 
-#: extension.js:733
+#: extension.js:755
 #, fuzzy
 msgid "Night Light paused"
 msgstr "Modalità di controllo della modalità notturna"
 
-#: extension.js:738
+#: extension.js:760
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine aktiviert"
 
-#: extension.js:740
+#: extension.js:762
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "Modalità di controllo della modalità notturna"
@@ -130,7 +130,7 @@ msgstr "Mostra notifiche quando abilitato/disabilitato"
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "Mostra indicatore nel pannello in alto"
 
 #: preferences/displayPage.js:99
@@ -141,65 +141,81 @@ msgstr ""
 msgid "For apps on list"
 msgstr "Per le applicazioni in elenco"
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr "Generali"
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr "Comportamento"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Abilita quando è avviata una applicazione a schermo intero"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "Abilita automaticamente quando un'app entra in modalità schermo intero"
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr "Ricorda stato"
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "Ripristina lo stato dopo i riavvii"
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 #, fuzzy
 msgid "Pause and resume Night Light"
 msgstr "Mostra notifiche quando abilitato/disabilitato"
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Attiva la modalità notturna insieme allo stato di caffeine"
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Mostra notifiche quando abilitato/disabilitato"
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr ""
 
@@ -233,86 +249,91 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+msgid "Specify index of duration range for the timer"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Restore caffeine state"
 msgstr "Ripristina lo stato di caffeine"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr "Mostra indicatore"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show the indicator on the top panel"
 msgstr "Mostra indicatore nel pannello in alto"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show notifications"
 msgstr "Mostra notifiche"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr "Mostra notifiche quando abilitato/disabilitato"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Mostra notifiche quando abilitato/disabilitato"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "Abilita quando è avviata una applicazione a schermo intero"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr "Modalità di controllo della modalità notturna"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 "Imposta il modo in cui caffeine interagisce con l'impostazione della "
 "Modalità notturna."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Mostra notifiche quando abilitato/disabilitato"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 #, fuzzy
 msgid "Trigger App control mode"
 msgstr "Modalità di controllo della modalità notturna"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/ja/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/ja/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2017-05-05 22:28+0900\n"
 "Last-Translator: Jean-Philippe Braun <eon@patapon.info>\n"
 "Language-Team: French\n"
@@ -17,28 +17,28 @@ msgstr ""
 "X-Generator: Poedit 2.0.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:99
+#: extension.js:102
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr "Caféine est activé"
 
-#: extension.js:733
+#: extension.js:755
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:738
+#: extension.js:760
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caféine est activé"
 
-#: extension.js:740
+#: extension.js:762
 msgid "Night Light resumed"
 msgstr ""
 
@@ -125,7 +125,7 @@ msgstr ""
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "Caffeine をトップバーに表示する"
 
 #: preferences/displayPage.js:99
@@ -136,63 +136,79 @@ msgstr ""
 msgid "For apps on list"
 msgstr ""
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr ""
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "フルスクリーンアプリケーション実行時に有効にする"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr "状態を記憶"
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "再起動後も状態を維持する"
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 msgid "Pause and resume Night Light"
 msgstr ""
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr ""
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr ""
 
@@ -223,81 +239,86 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-msgid "Restore caffeine state"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+msgid "Specify index of duration range for the timer"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+msgid "Restore caffeine state"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show the indicator on the top panel"
 msgstr "Caffeine をトップバーに表示する"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show notifications"
 msgstr "通知を有効にする"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Show timer when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "フルスクリーンアプリケーション実行時に有効にする"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/ko/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/ko/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2022-09-10 10:53+0900\n"
 "Last-Translator: kuroehanako <kmj10727@gmail.com>\n"
 "Language-Team: \n"
@@ -15,28 +15,28 @@ msgstr ""
 "X-Poedit-Basepath: ../../gnome-shell-extension-caffeine-master\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: extension.js:99
+#: extension.js:102
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:733
+#: extension.js:755
 #, fuzzy
 msgid "Night Light paused"
 msgstr "야간 모드를 멈춥니"
 
-#: extension.js:738
+#: extension.js:760
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:740
+#: extension.js:762
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "야간 모드를 다시 켭니"
@@ -123,7 +123,7 @@ msgstr "카페인을 켜고 끌 때마다 알림을 표시합니다."
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "상단 패널에 인디케이터 표시"
 
 #: preferences/displayPage.js:99
@@ -134,62 +134,78 @@ msgstr ""
 msgid "For apps on list"
 msgstr "목록에 있는 프로그램만"
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr "일반"
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 msgid "Enable for fullscreen apps"
 msgstr "전체 화면 프로그램에서 활성화"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "전체 화면 모드에 진입한 프로그램을 사용할 시 자동으로 활성화합니다."
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr "상태 기억하기"
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 msgid "Remember the last state across sessions and reboots"
 msgstr "세션을 바꾸거나 다시 시작할 때 마지막 상태를 기억합니다."
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 msgid "Pause and resume Night Light"
 msgstr "야간 모드를 멈추거나 다시 켜기"
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "카페인의 상태에 맞춰 야간 모드를 제어합니다."
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "카페인을 켜고 끌 때마다 알림을 표시합니다."
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr ""
 
@@ -221,84 +237,89 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+msgid "Specify index of duration range for the timer"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Restore caffeine state"
 msgstr "카페인 상태를 복원"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr "인디케이터 표시"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show the indicator on the top panel"
 msgstr "상단 패널에 인디케이터 표시"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show notifications"
 msgstr "알림 표시"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr "카페인을 켜고 끌 때마다 알림 표시"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "카페인을 켜고 끌 때마다 알림 표시"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "전체 화면 프로그램을 실행할 시 카페인 활성화"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr "야간 모드 제어 모드"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr "카페인 설정을 야간 모드 설정에 연동시킵니다."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "카페인을 켜고 끌 때마다 알림을 표시합니다."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 #, fuzzy
 msgid "Trigger App control mode"
 msgstr "야간 모드 제어 모드"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/nl/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/nl/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2023-02-07 14:23+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch\n"
@@ -17,27 +17,27 @@ msgstr ""
 "X-Generator: Poedit 3.2.2\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:99
+#: extension.js:102
 msgid "Caffeine timer"
 msgstr "Caffeine-tijdklok"
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr "Onbeperkt"
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr "Caffeine is ingeschakeld"
 
-#: extension.js:733
+#: extension.js:755
 msgid "Night Light paused"
 msgstr "Nachtlicht is onderbroken"
 
-#: extension.js:738
+#: extension.js:760
 msgid "Caffeine disabled"
 msgstr "Caffeine is uitgeschakeld"
 
-#: extension.js:740
+#: extension.js:762
 msgid "Night Light resumed"
 msgstr "Nachtlicht is hervat"
 
@@ -118,7 +118,8 @@ msgid "Enable notifications when Caffeine is enabled or disabled"
 msgstr "Toon meldingen als Caffeine wordt in- of uitgeschakeld"
 
 #: preferences/displayPage.js:98
-msgid "Status indicator Position"
+#, fuzzy
+msgid "Status indicator position"
 msgstr "Locatie van indicator"
 
 #: preferences/displayPage.js:99
@@ -129,62 +130,78 @@ msgstr "De locatie van de indicator ten opzichte van andere items"
 msgid "For apps on list"
 msgstr "Bij toepassingen op de lijst"
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr "Algemeen"
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr "Gedrag"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 msgid "Enable for fullscreen apps"
 msgstr "Inschakelen bij schermvullende toepassingen"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 "Schakel automatisch in als een toepassing de schermvullende modus gebruikt"
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr "Status onthouden"
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 msgid "Remember the last state across sessions and reboots"
 msgstr "Herstel de recentste status na wisselen van sessie en herstarten"
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 msgid "Pause and resume Night Light"
 msgstr "Nachtlicht onderbreken en hervatten"
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Schakel nachtlicht tegelijk met Caffeine in/uit"
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr "Scherm uitschakelen"
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Schakel het scherm uit als Caffeine wordt ingeschakeld"
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 msgid "Shortcut"
 msgstr "Sneltoets"
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr "Aan-/Uitsneltoets"
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr "Druk op backspace om te wissen"
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr "Nieuwe sneltoets…"
 
@@ -217,75 +234,81 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr "Geef aan hoelang de tijdklok dient af te tellen (in minuten)"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+#, fuzzy
+msgid "Specify index of duration range for the timer"
+msgstr "Geef aan hoelang de tijdklok dient af te tellen (in minuten)"
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Restore caffeine state"
 msgstr "Vorige status herstellen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr "Indicator tonen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show the indicator on the top panel"
 msgstr "Toon de indicator op de bovenbalk"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show notifications"
 msgstr "Meldingen tonen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr "Toon meldingen als Caffeine wordt in- of uitgeschakeld"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr "Tijdklok tonen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Show timer when enabled/disabled"
 msgstr "Toon een tijdklok na in- of uitschakelen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "Inschakelen als een toepassing de schermvullende modus gebruikt"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr "Nachtlichtbediening"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr "Geef aan hoe Caffeine dient om te gaan met de nachtlichtinstelling."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Schakel het scherm uit als Caffeine wordt ingeschakeld."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Trigger App control mode"
 msgstr "Aan-/Uitbedieningsmodus"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr "Stel de aan-/uitmethode van toepassingen in."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr "Sneltoets om Caffeine aan/uit te zetten."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr "Standaardbreedte van het voorkeurenvenster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr "Standaardhoogte van het voorkeurenvenster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr "Zichtbare locatieverschuiving van het pictogram in het indicatormenu"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
@@ -293,7 +316,7 @@ msgstr ""
 "Daadwerkelijke locatieverschuiving van het pictogram in het indicatormenu, "
 "inclusief het niet-getoonde"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr "Vorige itemlocatie in indicatormenu"
 

--- a/caffeine@patapon.info/locale/pl/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/pl/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2016-10-02 17:24+0100\n"
 "Last-Translator: Piotr Wittchen <piotr@wittchen.biz.pl>\n"
 "Language-Team: Polish\n"
@@ -17,28 +17,28 @@ msgstr ""
 "X-Generator: Vim\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:99
+#: extension.js:102
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr "Caffeine włączone"
 
-#: extension.js:733
+#: extension.js:755
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:738
+#: extension.js:760
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine włączone"
 
-#: extension.js:740
+#: extension.js:762
 msgid "Night Light resumed"
 msgstr ""
 
@@ -125,7 +125,7 @@ msgstr ""
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "Pokazuj Caffeine w górnym panelu"
 
 #: preferences/displayPage.js:99
@@ -136,62 +136,78 @@ msgstr ""
 msgid "For apps on list"
 msgstr ""
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr ""
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Włącz kiedy aplikacja jest uruchomiona w trybie pełnoekranowym"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr ""
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 msgid "Remember the last state across sessions and reboots"
 msgstr ""
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 msgid "Pause and resume Night Light"
 msgstr ""
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr ""
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr ""
 
@@ -223,83 +239,88 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-msgid "Restore caffeine state"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+msgid "Specify index of duration range for the timer"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+msgid "Restore caffeine state"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 #, fuzzy
 msgid "Show the indicator on the top panel"
 msgstr "Pokazuj Caffeine w górnym panelu"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 #, fuzzy
 msgid "Show notifications"
 msgstr "Włącz notyfikacje"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Show timer when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "Włącz kiedy aplikacja jest uruchomiona w trybie pełnoekranowym"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/pt_BR/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/pt_BR/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2020-02-25 20:16-0300\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
 "Language-Team: Brazilian Portuguese <gnome-pt_br-list@gnome.org>\n"
@@ -22,28 +22,28 @@ msgstr ""
 "X-Generator: Gtranslator 3.32.0\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:99
+#: extension.js:102
 msgid "Caffeine timer"
 msgstr "Temporizador do Caffeine"
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr "Infinito"
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr "Caffeine ativado"
 
-#: extension.js:733
+#: extension.js:755
 msgid "Night Light paused"
 msgstr "Luz Noturna pausado"
 
-#: extension.js:738
+#: extension.js:760
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine desativado"
 
-#: extension.js:740
+#: extension.js:762
 msgid "Night Light resumed"
 msgstr "Luz Noturna resumido"
 
@@ -131,7 +131,7 @@ msgstr "Mostra notificações quando ativado/desativado"
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "Mostrar o indicador no painel superior"
 
 #: preferences/displayPage.js:99
@@ -142,65 +142,81 @@ msgstr "Posição do indicador em relação aos outros icones"
 msgid "For apps on list"
 msgstr "Para aplicativos na lista"
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr "Geral"
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr "Comportamento"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Ativar enquanto um aplicativo em tela cheia estiver executando"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr "Lembrar estado"
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "Restaurar estado entre reinicializações"
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 #, fuzzy
 msgid "Pause and resume Night Light"
 msgstr "Mostra notificações quando ativado/desativado"
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Alternar Luz Noturna junto do estado do Caffeine"
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr "Permitir tela desligada"
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Permitir desligar a tela quando o Caffeine está ativado"
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 msgid "Shortcut"
 msgstr "Atalho"
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr "Atalho para alternar"
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr "Use Backspace para limpar"
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr "Nova combinação..."
 
@@ -234,83 +250,90 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr "Especifique o tempo do temporizador em minutos"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+#, fuzzy
+msgid "Specify index of duration range for the timer"
+msgstr "Especifique o tempo do temporizador em minutos"
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Restore caffeine state"
 msgstr "Restaurar estado do caffeine"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr "Mostrar indicador"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show the indicator on the top panel"
 msgstr "Mostrar o indicador no painel superior"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show notifications"
 msgstr "Mostrar notificações"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr "Mostra notificações quando ativado/desativado"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr "Mostrar temporizador"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Mostra notificações quando ativado/desativado"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "Ativar enquanto um aplicativo em tela cheia estiver executando"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr "Modo de controle da Luz Noturna"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
-msgid "Set the way Caffeine interacts with the Night light setting."
-msgstr "Configure a maneira que o Caffeine interage com a configuração da Luz Noturna"
-
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+msgid "Set the way Caffeine interacts with the Night light setting."
+msgstr ""
+"Configure a maneira que o Caffeine interage com a configuração da Luz Noturna"
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Mostra notificações quando ativado/desativado"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Trigger App control mode"
 msgstr "Modo de controle do Gatilho de Aplicativos"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr "Configure o metodo de gatilho para aplicativos"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr "Atalho para alterar o Caffeine"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr "Largura padrão para a janela de configurações"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr "Altura padrão para a janela de configurações"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr "Deslocamento visível da posição do icone"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr "Último índice do icone do menu indicador"
 

--- a/caffeine@patapon.info/locale/pt_PT/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/pt_PT/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2016-12-02 10:01+0100\n"
 "Last-Translator: Steeven Lopes <steevenlopes@outlook.com>\n"
 "Language-Team: Portuguese\n"
@@ -17,28 +17,28 @@ msgstr ""
 "X-Generator: Poedit 1.6.10\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:99
+#: extension.js:102
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr "Caffeine ativado"
 
-#: extension.js:733
+#: extension.js:755
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:738
+#: extension.js:760
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine ativado"
 
-#: extension.js:740
+#: extension.js:762
 msgid "Night Light resumed"
 msgstr ""
 
@@ -125,7 +125,7 @@ msgstr ""
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "Mostrar Caffeine no painel superior"
 
 #: preferences/displayPage.js:99
@@ -136,62 +136,78 @@ msgstr ""
 msgid "For apps on list"
 msgstr ""
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr ""
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Ativar quando uma aplicação estiver a correr no modo ecrã inteiro"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr ""
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 msgid "Remember the last state across sessions and reboots"
 msgstr ""
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 msgid "Pause and resume Night Light"
 msgstr ""
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr ""
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr ""
 
@@ -223,83 +239,88 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-msgid "Restore caffeine state"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+msgid "Specify index of duration range for the timer"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+msgid "Restore caffeine state"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 #, fuzzy
 msgid "Show the indicator on the top panel"
 msgstr "Mostrar Caffeine no painel superior"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 #, fuzzy
 msgid "Show notifications"
 msgstr "Ativar notificações"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Show timer when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "Ativar quando uma aplicação estiver a correr no modo ecrã inteiro"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/ru/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/ru/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2022-02-08 13:07+0300\n"
 "Last-Translator: Aleksandr Melman <Alexmelman88@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -17,28 +17,28 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:99
+#: extension.js:102
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:733
+#: extension.js:755
 #, fuzzy
 msgid "Night Light paused"
 msgstr "Ночная подсветка"
 
-#: extension.js:738
+#: extension.js:760
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:740
+#: extension.js:762
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "Ночная подсветка"
@@ -125,7 +125,7 @@ msgstr "Включить уведомления о включении или о�
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "Показывать индикатор состояния на верхней панели"
 
 #: preferences/displayPage.js:99
@@ -136,63 +136,79 @@ msgstr ""
 msgid "For apps on list"
 msgstr "Для приложений из списка"
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr "Общие"
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 msgid "Enable for fullscreen apps"
 msgstr "Включить для полноэкранных приложений"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 "Автоматически включать, когда приложение переходит в полноэкранный режим"
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr "Запомнить состояние"
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 msgid "Remember the last state across sessions and reboots"
 msgstr "Запомнить последнее состояние после смены сеанса и перезагрузки"
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 msgid "Pause and resume Night Light"
 msgstr "Приостановка и возобновление ночной подсветки"
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Переключение ночной подсветки вместе с состоянием Кофеина"
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Включить уведомления о включении или отключении Кофеина"
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr ""
 
@@ -224,84 +240,89 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+msgid "Specify index of duration range for the timer"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Restore caffeine state"
 msgstr "Восстановить состояние приложения"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr "Показывать индикатор"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show the indicator on the top panel"
 msgstr "Показать индикатор на верхней панели"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show notifications"
 msgstr "Показывать уведомления"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr "Показывать уведомление, когда включено/выключено"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Показывать уведомление, когда включено/выключено"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "Включать, когда запущено полноэкранное приложение"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr "Режим управления ночной подсветкой"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr "Настроить взаимодействие Кофеина с параметром \"Ночная подсветка\"."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Включить уведомления о включении или отключении Кофеина"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 #, fuzzy
 msgid "Trigger App control mode"
 msgstr "Режим управления ночной подсветкой"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/sk/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/sk/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2015-01-16 10:24+0100\n"
 "Last-Translator: Dušan Kazik <prescott66@gmail.com>\n"
 "Language-Team: Slovak\n"
@@ -17,28 +17,28 @@ msgstr ""
 "X-Generator: Poedit 1.7.3\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:99
+#: extension.js:102
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr "Caffeine aktiviert"
 
-#: extension.js:733
+#: extension.js:755
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:738
+#: extension.js:760
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine aktiviert"
 
-#: extension.js:740
+#: extension.js:762
 msgid "Night Light resumed"
 msgstr ""
 
@@ -125,7 +125,7 @@ msgstr ""
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "Zobraziť Caffeine v hornej lište"
 
 #: preferences/displayPage.js:99
@@ -136,62 +136,78 @@ msgstr ""
 msgid "For apps on list"
 msgstr ""
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr ""
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Povoliť, keď je spustená aplikácia v režime na celú obrazovku"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr ""
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 msgid "Remember the last state across sessions and reboots"
 msgstr ""
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 msgid "Pause and resume Night Light"
 msgstr ""
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr ""
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr ""
 
@@ -223,83 +239,88 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-msgid "Restore caffeine state"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+msgid "Specify index of duration range for the timer"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+msgid "Restore caffeine state"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 #, fuzzy
 msgid "Show the indicator on the top panel"
 msgstr "Zobraziť Caffeine v hornej lište"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 #, fuzzy
 msgid "Show notifications"
 msgstr "Povoliť oznámenia"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Show timer when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "Povoliť, keď je spustená aplikácia v režime na celú obrazovku"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/sv/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/sv/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2018-04-04 20:35+0200\n"
 "Last-Translator: Morgan Antonsson <morgan.antonsson@gmail.com>\n"
 "Language-Team: \n"
@@ -11,27 +11,27 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: extension.js:99
+#: extension.js:102
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:733
+#: extension.js:755
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:738
+#: extension.js:760
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:740
+#: extension.js:762
 msgid "Night Light resumed"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Visa notifieringar vid aktivering/inaktivering"
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "Visa indikator i panelen"
 
 #: preferences/displayPage.js:99
@@ -130,65 +130,81 @@ msgstr ""
 msgid "For apps on list"
 msgstr ""
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr ""
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Aktivera när ett program använder helskärmsläget"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr ""
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "Återställ tillstånd efter omstart"
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 #, fuzzy
 msgid "Pause and resume Night Light"
 msgstr "Visa notifieringar vid aktivering/inaktivering"
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Visa notifieringar vid aktivering/inaktivering"
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr ""
 
@@ -220,83 +236,88 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+msgid "Specify index of duration range for the timer"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Restore caffeine state"
 msgstr "Återställ caffeine-status"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr "Visa indikator"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show the indicator on the top panel"
 msgstr "Visa indikator i panelen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show notifications"
 msgstr "Visa notifieringar"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr "Visa notifieringar vid aktivering/inaktivering"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Visa notifieringar vid aktivering/inaktivering"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "Aktivera när ett program använder helskärmsläget"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Visa notifieringar vid aktivering/inaktivering"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/tr/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/tr/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2019-03-21 06:48+0300\n"
 "Last-Translator: Serdar Sağlam <teknomobil@yandex.com>\n"
 "Language-Team: Turkish <gnome-turk@gnome.org>\n"
@@ -18,28 +18,28 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Generator: Gtranslator 3.32.0\n"
 
-#: extension.js:99
+#: extension.js:102
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr "Caffeine aktif"
 
-#: extension.js:733
+#: extension.js:755
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:738
+#: extension.js:760
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine aktif"
 
-#: extension.js:740
+#: extension.js:762
 msgid "Night Light resumed"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr "Aktif/Pasif olduğunda bildirimleri göster"
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "Göstergeyi üst panelde göster"
 
 #: preferences/displayPage.js:99
@@ -138,65 +138,81 @@ msgstr ""
 msgid "For apps on list"
 msgstr ""
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr ""
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Tam ekran uygulama çalıştırıldığı zaman aktif olacaktır"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr ""
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "Yeniden başlatma arasında durumu geri yükle"
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 #, fuzzy
 msgid "Pause and resume Night Light"
 msgstr "Aktif/Pasif olduğunda bildirimleri göster"
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Aktif/Pasif olduğunda bildirimleri göster"
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr ""
 
@@ -229,83 +245,88 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+msgid "Specify index of duration range for the timer"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Restore caffeine state"
 msgstr "Kafein durumunu geri yükle"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr "Göstergeyi göster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show the indicator on the top panel"
 msgstr "Göstergeyi üst panelde göster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show notifications"
 msgstr "Bildirimleri göster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr "Aktif/Pasif olduğunda bildirimleri göster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Aktif/Pasif olduğunda bildirimleri göster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "Tam ekran uygulama çalıştırıldığı zaman aktif olacaktır"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Aktif/Pasif olduğunda bildirimleri göster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/zh_CN/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/zh_CN/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-16 08:54+0100\n"
+"POT-Creation-Date: 2023-03-11 23:33+0000\n"
 "PO-Revision-Date: 2022-06-30 11:54-0400\n"
 "Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <debian-l10n-chinese@lists.debian.org>\n"
@@ -17,29 +17,29 @@ msgstr ""
 "X-Generator: Poedit 3.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:99
+#: extension.js:102
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:126
+#: extension.js:218
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:731
+#: extension.js:753
 msgid "Caffeine enabled"
 msgstr "Caffeine 已开启"
 
-#: extension.js:733
+#: extension.js:755
 #, fuzzy
 msgid "Night Light paused"
 msgstr "夜灯已暂停"
 
-#: extension.js:738
+#: extension.js:760
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine 已开启"
 
-#: extension.js:740
+#: extension.js:762
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "夜灯已恢复"
@@ -126,7 +126,7 @@ msgstr "在 Caffeine 被启用或禁用时显示通知"
 
 #: preferences/displayPage.js:98
 #, fuzzy
-msgid "Status indicator Position"
+msgid "Status indicator position"
 msgstr "在顶部面板显示状态指示器"
 
 #: preferences/displayPage.js:99
@@ -137,62 +137,78 @@ msgstr ""
 msgid "For apps on list"
 msgstr "用于列表上的应用"
 
-#: preferences/generalPage.js:39
+#: preferences/generalPage.js:47
 msgid "General"
 msgstr "常规"
 
-#: preferences/generalPage.js:49
+#: preferences/generalPage.js:57
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:66
 msgid "Enable for fullscreen apps"
 msgstr "为全屏程序启用"
 
-#: preferences/generalPage.js:59
+#: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "在有应用进入全屏模式时自动启用"
 
-#: preferences/generalPage.js:70
+#: preferences/generalPage.js:78
 msgid "Remember state"
 msgstr "记住状态"
 
-#: preferences/generalPage.js:71
+#: preferences/generalPage.js:79
 msgid "Remember the last state across sessions and reboots"
 msgstr "跨会话和重启记住上一次的状态"
 
-#: preferences/generalPage.js:82
+#: preferences/generalPage.js:90
 msgid "Pause and resume Night Light"
 msgstr "暂停和恢复夜灯"
 
-#: preferences/generalPage.js:83
+#: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "随 Caffeine 的状态切换夜灯"
 
-#: preferences/generalPage.js:94
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: preferences/generalPage.js:102
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:95
+#: preferences/generalPage.js:103
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "在 Caffeine 被启用或禁用时显示通知"
 
-#: preferences/generalPage.js:117
+#: preferences/generalPage.js:118
+msgid "Timer"
+msgstr ""
+
+#: preferences/generalPage.js:123
+msgid "Durations"
+msgstr ""
+
+#: preferences/generalPage.js:167
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:125
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: preferences/generalPage.js:175
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:126
+#: preferences/generalPage.js:176
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:204 preferences/generalPage.js:236
+#: preferences/generalPage.js:217
+msgid "Set to "
+msgstr ""
+
+#: preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
 msgstr ""
 
@@ -224,84 +240,89 @@ msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+msgid "Specify index of duration range for the timer"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Restore caffeine state"
 msgstr "恢复 caffeine 状态"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show indicator"
 msgstr "显示指示器"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show the indicator on the top panel"
 msgstr "在顶部面板显示指示器"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show notifications"
 msgstr "显示通知"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show notifications when enabled/disabled"
 msgstr "启用/禁用时显示通知"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "启用/禁用时显示通知"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Enable when a fullscreen application is running"
 msgstr "运行全屏程序时自动启动"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Night Light control mode"
 msgstr "夜灯控制模式"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr "设置 Caffeine 和夜灯设置交互的方式。"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "在 Caffeine 被启用或禁用时显示通知"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 #, fuzzy
 msgid "Trigger App control mode"
 msgstr "夜灯控制模式"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/preferences/displayPage.js
+++ b/caffeine@patapon.info/preferences/displayPage.js
@@ -95,7 +95,7 @@ class Caffeine_DisplayPage extends Adw.PreferencesPage {
             valign: Gtk.Align.CENTER
         });
         let posIndicatorOffsetRow = new Adw.ActionRow({
-            title: _("Status indicator Position"),
+            title: _("Status indicator position"),
             subtitle: _("The position relative of indicator icon to other items"),
             activatable_widget: this.posIndicatorOffsetButton
         });


### PR DESCRIPTION
 - 'Position' was unnecessarily capitalised in the position section of preferences, fixed
 - Also updated locales, as this string was translated
   - Some strings hadn't been updated from previous commits, these are done too