### PR TITLE
Place toggle above background apps

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -404,6 +404,14 @@ class Caffeine extends QuickSettings.SystemIndicator {
         QuickSettingsMenu._indicators.insert_child_at_index(this,this.indicatorIndex);
         QuickSettingsMenu._addItems(this.quickSettingsItems);
 
+        // Place the toggle above the background apps entry
+        if (ShellVersion >= 44) {
+            this.quickSettingsItems.forEach((item) => {
+                QuickSettingsMenu.menu._grid.set_child_below_sibling(item,
+                    QuickSettingsMenu._backgroundApps.quickSettingsItems[0]);
+            });
+        }
+
         this._updateLastIndicatorPosition();
     }
 


### PR DESCRIPTION
On GNOME 44, the background apps gets placed above Caffeine's indicator, leaving caps and splitting the toggles. When Caffeine loads, move the toggle above the background apps entry instead.

Closes #249