### PR TITLE
Timer behavior & Gnome 44 adjustment

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -391,9 +391,6 @@ class Caffeine extends QuickSettings.SystemIndicator {
             this._resetAppSignalId();
             this._updateAppEventMode();
         });
-        this.connect('destroy', () => {
-            this.quickSettingsItems.forEach(item => item.destroy());
-        });
 
         // Change user state on icon scroll event
         this._indicator.reactive = true;
@@ -1030,6 +1027,9 @@ class Caffeine extends QuickSettings.SystemIndicator {
         // Remove all inhibitors
         this._appInhibitedData.forEach((data, appId) => this.removeInhibit(appId));
         this._appInhibitedData.clear();
+
+        // Remove ToggleMenu
+        this.quickSettingsItems.forEach(item => item.destroy());
 
         // Disconnect from signals
         if (this._settings.get_boolean(FULLSCREEN_KEY)) {

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -215,7 +215,7 @@ class CaffeineToggle extends QuickSettings.QuickMenuToggle {
             if(timer[0] === 0) {
                 label = _('Infinite');
             } else {
-                label = parseInt(timer[durationIndex]) + 'm';
+                label = parseInt(timer[durationIndex]) + _(' minutes');
             }
             if (!label)
                 continue;
@@ -790,7 +790,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
         if (ShellVersion >= 44 && !this._settings.get_boolean(TOGGLE_STATE_KEY)) {
             const timerDuration = this._settings.get_int(TIMER_KEY);
             this._caffeineToggle.subtitle = timerDuration !== 0 
-                ? parseInt(timerDuration) + "m" 
+                ? parseInt(timerDuration) + _(' minutes')
                 : null;
         }
     }

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -340,15 +340,6 @@ class Caffeine extends QuickSettings.SystemIndicator {
         this._timeWorkspaceRemove = null;
         this._timeAppUnblock = null;
 
-        // Init settings keys and restore user state
-        this._settings.reset(TOGGLE_STATE_KEY);
-        if (this._settings.get_boolean(USER_ENABLED_KEY) && this._settings.get_boolean(RESTORE_KEY)) {
-            this.toggleState();
-        } else {
-            // reset user state
-            this._settings.reset(USER_ENABLED_KEY);
-        }
-
         // Show icon
         this._manageShowIndicator();
 
@@ -367,6 +358,15 @@ class Caffeine extends QuickSettings.SystemIndicator {
         this._caffeineToggle = new CaffeineToggle();
         this.quickSettingsItems.push(this._caffeineToggle);
         this._updateTimerSubtitle();
+
+        // Init settings keys and restore user state
+        this._settings.reset(TOGGLE_STATE_KEY);
+        if (this._settings.get_boolean(USER_ENABLED_KEY) && this._settings.get_boolean(RESTORE_KEY)) {
+            this.toggleState();
+        } else {
+            // reset user state
+            this._settings.reset(USER_ENABLED_KEY);
+        }
 
         // Bind signals
         this._inhibitorAddedId = this._sessionManager.connectSignal(

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -767,18 +767,11 @@ class Caffeine extends QuickSettings.SystemIndicator {
         }
     }
 
-    // Add the name of App as toggle button subtitle (=< Gnome 44)
+    // Add the name of App as subtitle (=< Gnome 44)
     _updateAppsSubtitle(id) {
         if (ShellVersion >= 44) {
             const listAppId = this._appInhibitedData.keys();
             let appId = id !== null ? id : listAppId.next().value;
-            //let appId = null;
-            
-            //if(id !== null) {
-            //    appId = id;
-            //} else {                          
-            //    appId = listAppId.next().value;
-            //}
             if (appId !== undefined) {
                 let appInfo = Gio.DesktopAppInfo.new(appId);        
                 this._caffeineToggle.subtitle = appInfo.get_display_name();

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -184,7 +184,6 @@ class CaffeineToggle extends QuickSettings.QuickMenuToggle {
         // Init Timers
         this._timerItems = new Map();
         this._syncTimers(false);
-        //this._sync();
 
         // Bind signals
         this._settings.bind(`${TOGGLE_STATE_KEY}`,

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -444,7 +444,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
     toggleState() {
         this._manageScreenBlankState(false);
         if (this._state) {
-            this._removeTimer(false);
+            this._removeTimer();
             this._appInhibitedData.forEach((data, appId) =>
                 this.removeInhibit(appId)
             );
@@ -554,10 +554,9 @@ class Caffeine extends QuickSettings.SystemIndicator {
     }
 
     _startTimer() {
-        this._timerEnable = true;
-
         // Reset timer
-        this._removeTimer(true);
+        this._removeTimer();
+        this._timerEnable = true;
 
         // Get duration
         let timerDelay = (this._settings.get_int(TIMER_KEY) * 60);
@@ -575,7 +574,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
 
             this._timeOut = GLib.timeout_add(GLib.PRIORITY_DEFAULT, (timerDelay * 1000), () => {
                 // Disable Caffeine when timer ended
-                this._removeTimer(false);
+                this._removeTimer();
                 this._settings.set_boolean(TOGGLE_STATE_KEY, false);
                 return GLib.SOURCE_REMOVE;
             });
@@ -592,12 +591,13 @@ class Caffeine extends QuickSettings.SystemIndicator {
         this._updateLabelTimer(min + ':' + minS);
     }
 
-    _removeTimer(reset) {
-        if(!reset) {
-            // End timer
-            this._timerEnable = false;
-        }
+    _removeTimer() {
+        // End timer
+        this._timerEnable = false;
+
+        // Flush and hide timer label 
         this._updateLabelTimer(null);
+        this._timerLabel.visible = false;
 
         // Remove timer
         if((this._timeOut !== null) || (this._timePrint !== null)) {
@@ -627,7 +627,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
             case Clutter.ScrollDirection.DOWN:
                 if(this._state) {
                     // Stop timer
-                    this._removeTimer(false);
+                    this._removeTimer();
                     // User state off - DOWN
                     this._settings.set_boolean(TOGGLE_STATE_KEY, false);
                 }

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -228,7 +228,7 @@ class CaffeineToggle extends QuickSettings.QuickMenuToggle {
         this.menuEnabled = TIMERS.length > 2;
      
         // Select active duration
-        if(resetDefault && this._settings.get_int(TIMER_KEY) !== 0) {
+        if (resetDefault && this._settings.get_int(TIMER_KEY) !== 0) {
             // Set default duration to 0
             this._settings.set_int(TIMER_KEY, 0);
         } else {
@@ -563,7 +563,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
         let timerDelay = (this._settings.get_int(TIMER_KEY) * 60);
 
         // Execute Timer only if duration isn't set on infinite time
-        if(timerDelay !== 0) {
+        if (timerDelay !== 0) {
             let secondLeft = timerDelay;
             this._showIndicatorLabel();
             this._printTimer(secondLeft);
@@ -982,7 +982,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
 
             // Uninhibit previous focused apps
             this._appInhibitedData.forEach((data, id) => {
-                if(id !== appId){
+                if (id !== appId) {
                     this.removeInhibit(id);
                 }
             });

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -773,7 +773,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
         }
     }
 
-    // Add the name of App as subtitle (=< Gnome 44)
+    // Add the name of App as subtitle (>= Gnome 44)
     _updateAppSubtitle(id) {
         if (ShellVersion >= 44) {
             const listAppId = this._appInhibitedData.keys();
@@ -785,7 +785,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
         }
     }
 
-    // Add the timer duration selected as subtitle (=< Gnome 44)
+    // Add the timer duration selected as subtitle (>= Gnome 44)
     _updateTimerSubtitle() {
         if (ShellVersion >= 44 && !this._settings.get_boolean(TOGGLE_STATE_KEY)) {
             const timerDuration = this._settings.get_int(TIMER_KEY);

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -982,7 +982,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
 
             // Uninhibit previous focused apps
             this._appInhibitedData.forEach((data, id) => {
-                if (id !== appId) {
+                if (id !== appId && id !== 'user') {
                     this.removeInhibit(id);
                 }
             });
@@ -991,7 +991,9 @@ class Caffeine extends QuickSettings.SystemIndicator {
             this._manageNightLight(true, true);
             // Uninhibit all apps
             this._appInhibitedData.forEach((data, id) => {
-                this.removeInhibit(id);
+                if (id !== 'user') {
+                    this.removeInhibit(id);
+                }
             });
         }
     }

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -366,6 +366,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
         // QuickSettings
         this._caffeineToggle = new CaffeineToggle();
         this.quickSettingsItems.push(this._caffeineToggle);
+        this._updateTimerSubtitle();
 
         // Bind signals
         this._inhibitorAddedId = this._sessionManager.connectSignal(
@@ -775,9 +776,17 @@ class Caffeine extends QuickSettings.SystemIndicator {
             if (appId !== undefined) {
                 let appInfo = Gio.DesktopAppInfo.new(appId);        
                 this._caffeineToggle.subtitle = appInfo.get_display_name();
-            } else {
-                this._caffeineToggle.subtitle = null;
             }
+        }
+    }
+
+    // Add the timer duration selected as subtitle (=< Gnome 44)
+    _updateTimerSubtitle() {
+        if (ShellVersion >= 44 && !this._settings.get_boolean(TOGGLE_STATE_KEY)) {
+            const timerDuration = this._settings.get_int(TIMER_KEY);
+            this._caffeineToggle.subtitle = timerDuration !== 0 
+                ? parseInt(timerDuration) + "m" 
+                : null;
         }
     }
 
@@ -808,11 +817,13 @@ class Caffeine extends QuickSettings.SystemIndicator {
         if (caffeineToggleState !== this._state) {
             this.toggleState();
 
-            // Enable timer when duration is not set to zero
+            // Enable timer when duration is not set to zero            
             if (caffeineToggleState && this._settings.get_int(TIMER_KEY) !== 0 && !this._timerEnable) {
                 this._startTimer();
             }
         }
+        // Add timer duration as Subtitle when disable
+        this._updateTimerSubtitle();
     }
 
     _saveUserState(state) {

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -452,6 +452,11 @@ class Caffeine extends QuickSettings.SystemIndicator {
         } else {
             this.addInhibit('user');
             this._manageNightLight(false, false);
+
+            // Enable timer when duration isn't null
+            if (this._settings.get_int(TIMER_KEY) !== 0 && !this._timerEnable) {
+                this._startTimer();
+            }
         }
     }
 
@@ -813,14 +818,8 @@ class Caffeine extends QuickSettings.SystemIndicator {
     }
 
     _updateMainState() {
-        const caffeineToggleState = this._settings.get_boolean(TOGGLE_STATE_KEY);
-        if (caffeineToggleState !== this._state) {
+        if (this._settings.get_boolean(TOGGLE_STATE_KEY) !== this._state) {
             this.toggleState();
-
-            // Enable timer when duration is not set to zero            
-            if (caffeineToggleState && this._settings.get_int(TIMER_KEY) !== 0 && !this._timerEnable) {
-                this._startTimer();
-            }
         }
         // Add timer duration as Subtitle when disable
         this._updateTimerSubtitle();

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -787,11 +787,11 @@ class Caffeine extends QuickSettings.SystemIndicator {
         const caffeineToggleState = this._settings.get_boolean(TOGGLE_STATE_KEY);
         if (caffeineToggleState !== this._state) {
             this.toggleState();
-        }
 
-        // Enable timer when duration is not set to zero
-        if (caffeineToggleState && this._settings.get_int(TIMER_KEY) !== 0 && !this._timerEnable) {
-            this._startTimer();
+            // Enable timer when duration is not set to zero
+            if (caffeineToggleState && this._settings.get_int(TIMER_KEY) !== 0 && !this._timerEnable) {
+                this._startTimer();
+            }
         }
     }
 

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -649,7 +649,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
                         if (appId === 'user') {
                             this._saveUserState(true);
                         } else {
-                            this._updateAppsSubtitle(appId);
+                            this._updateAppSubtitle(appId);
                         }
 
                         // Update state
@@ -683,7 +683,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
                 if (appId === 'user') {
                     this._saveUserState(false);
                 } else {
-                    this._updateAppsSubtitle(null);
+                    this._updateAppSubtitle(null);
                 }
 
                 // Update state
@@ -768,7 +768,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
     }
 
     // Add the name of App as subtitle (=< Gnome 44)
-    _updateAppsSubtitle(id) {
+    _updateAppSubtitle(id) {
         if (ShellVersion >= 44) {
             const listAppId = this._appInhibitedData.keys();
             let appId = id !== null ? id : listAppId.next().value;

--- a/caffeine@patapon.info/locale/cs/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/cs/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2022-04-13 15:18+0200\n"
 "Last-Translator: Daniel Rusek <mail@asciiwolf.com>\n"
 "Language-Team: Czech\n"
@@ -17,28 +17,32 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:102
+#: extension.js:101
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:753
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: extension.js:760
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:755
+#: extension.js:762
 #, fuzzy
 msgid "Night Light paused"
 msgstr "Noční světlo"
 
-#: extension.js:760
+#: extension.js:767
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:762
+#: extension.js:769
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "Noční světlo obnoveno"
@@ -169,7 +173,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr "Přepne noční světlo spolu se stavem Caffeine"
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
@@ -191,7 +195,7 @@ msgid "Shortcut"
 msgstr ""
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
@@ -201,10 +205,6 @@ msgstr ""
 
 #: preferences/generalPage.js:217
 msgid "Set to "
-msgstr ""
-
-#: preferences/generalPage.js:217
-msgid " minutes"
 msgstr ""
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
@@ -230,99 +230,95 @@ msgid "Store caffeine user state"
 msgstr "Uložit uživatelský stav caffeine"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
+msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
-msgid "Specify time (minutes) for the timer countdown"
-msgstr ""
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
 msgid "Specify index of duration range for the timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr "Obnovit stav caffeine"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr "Zobrazit indikátor"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
 msgstr "Zobrazit indikátor v horní liště"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
 msgstr "Zobrazit upozornění"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr "Zobrazit upozornění, když je povoleno/zakázáno"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Zobrazit upozornění, když je povoleno/zakázáno"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "Povolit, když je spuštěná aplikace v režimu celé obrazovky"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr "Režim řízení Nočního světla"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 "Nastavte způsob, kterým Caffeine interaguje s nastavením Nočního světla."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Povolit upozornění, když je Caffeine povoleno nebo zakázáno"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 #, fuzzy
 msgid "Trigger App control mode"
 msgstr "Režim řízení Nočního světla"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/de/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/de/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2021-04-09 21:31-0400\n"
 "Last-Translator: WebSnke <websnke@tutanota.com>\n"
 "Language-Team: German\n"
@@ -17,27 +17,31 @@ msgstr ""
 "X-Generator: Poedit 2.4.2\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:102
+#: extension.js:101
 msgid "Caffeine timer"
 msgstr "Caffeine-Timer"
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr "Unendlich"
 
-#: extension.js:753
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
+msgstr " Minuten"
+
+#: extension.js:760
 msgid "Caffeine enabled"
 msgstr "Caffeine aktiviert"
 
-#: extension.js:755
+#: extension.js:762
 msgid "Night Light paused"
 msgstr "Nachtmodus pausiert"
 
-#: extension.js:760
+#: extension.js:767
 msgid "Caffeine disabled"
 msgstr "Caffeine deaktiviert"
 
-#: extension.js:762
+#: extension.js:769
 msgid "Night Light resumed"
 msgstr "Nachtmodus fortgesetzt"
 
@@ -162,7 +166,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr "Unterbricht den Nachtmodus wenn Caffeine aktiviert wird"
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "Erlaube es, den Bildschirm auszuschalten"
 
@@ -183,7 +187,7 @@ msgid "Shortcut"
 msgstr "Tastenkombination"
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
@@ -194,10 +198,6 @@ msgstr "Nutze die Leertaste zum löschen"
 #: preferences/generalPage.js:217
 msgid "Set to "
 msgstr "Einstellen auf"
-
-#: preferences/generalPage.js:217
-msgid " minutes"
-msgstr " Minuten"
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
@@ -224,97 +224,96 @@ msgid "Store caffeine user state"
 msgstr "Speichert die benutzerdefinierten Zustand"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
-msgstr "Countdown starten"
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
 msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
 msgid "Specify index of duration range for the timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr "Caffeines Zustand wiederherstellen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr "Indikator anzeigen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
 msgstr "Caffeine-Indikator in der oberen Leiste anzeigen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
 msgstr "Benachrichtigungen aktivieren"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr "Benachrichtigungen anzeigen, wenn aktiviert/deaktiviert"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr "Timer anzeigen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show timer when enabled/disabled"
 msgstr "Timer anzeigen, wenn aktiviert/deaktiviert"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "Aktivieren, sobald eine Anwendung im Vollbildmodus läuft"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr "Lege fest, wie Caffein mit dem Nachtmodus umgeht."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Ausschalten des Bildschirms, wenn Caffeine an ist, erlauben"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr "Tastenkombination um Caffeine zu öffnen."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr "Standardbreite für das Einstellungsfenster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr "Standardhöhe für das Einstellungsfenster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr ""
+
+#~ msgid "Start Timer countdown"
+#~ msgstr "Countdown starten"
 
 #~ msgid "Auto suspend and screensaver disabled"
 #~ msgstr "Bereitschaftsmodus und Bildschirmschoner deaktiviert"
@@ -339,7 +338,9 @@ msgstr ""
 
 #~ msgid ""
 #~ "Pause/resume Night Light for defined application when enabled/disabled"
-#~ msgstr "Nachtmodus pausieren/fortführen für eine bestimmte Anwendung, wenn aktiviert/deaktiviert"
+#~ msgstr ""
+#~ "Nachtmodus pausieren/fortführen für eine bestimmte Anwendung, wenn "
+#~ "aktiviert/deaktiviert"
 
 #~ msgid "Add Application"
 #~ msgstr "Anwendung hinzufügen"

--- a/caffeine@patapon.info/locale/es/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/es/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2015-11-28 21:06-0300\n"
 "Last-Translator: Sergio D. Márquez <marquez.sergio.d@gmail.com>\n"
 "Language-Team: Spanish\n"
@@ -17,29 +17,33 @@ msgstr ""
 "X-Generator: Poedit 1.8.6\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:102
+#: extension.js:101
 #, fuzzy
 msgid "Caffeine timer"
 msgstr "Caffeine temporizador"
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr "Infinito"
 
-#: extension.js:753
-msgid "Caffeine enabled"
-msgstr "Caffeine activado"
-
-#: extension.js:755
-msgid "Night Light paused"
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
 msgstr ""
 
 #: extension.js:760
+msgid "Caffeine enabled"
+msgstr "Caffeine activado"
+
+#: extension.js:762
+msgid "Night Light paused"
+msgstr ""
+
+#: extension.js:767
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine activado"
 
-#: extension.js:762
+#: extension.js:769
 msgid "Night Light resumed"
 msgstr ""
 
@@ -178,7 +182,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
@@ -200,7 +204,7 @@ msgid "Shortcut"
 msgstr "Atajo"
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
@@ -210,10 +214,6 @@ msgstr ""
 
 #: preferences/generalPage.js:217
 msgid "Set to "
-msgstr ""
-
-#: preferences/generalPage.js:217
-msgid " minutes"
 msgstr ""
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
@@ -242,99 +242,95 @@ msgid "Store caffeine user state"
 msgstr "Guardar estado de usuario de Caffeine"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
+msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
-msgid "Specify time (minutes) for the timer countdown"
-msgstr ""
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
 msgid "Specify index of duration range for the timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr "Restablecer estado de Caffeine"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr "Mostrar indicador"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 #, fuzzy
 msgid "Show the indicator on the top panel"
 msgstr "Mostrar Caffeine en el panel superior"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 #, fuzzy
 msgid "Show notifications"
 msgstr "Activar las notificaciones"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr "Mostrar notificaciones de habilitado/deshabilitado"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Mostrar notificaciones de habilitado/deshabilitado"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "Activar cuando una aplicación a pantalla completa esté en ejecución"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Mostrar notificaciones de habilitado/deshabilitado"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2022-10-07 16:40+0200\n"
 "Last-Translator: Simon Elst <kirmaha@duck.com>\n"
 "Language-Team: French\n"
@@ -22,30 +22,34 @@ msgstr ""
 "X-Generator: Poedit 3.1.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:102
+#: extension.js:101
 #, fuzzy
 msgid "Caffeine timer"
 msgstr "Caffeine minuteur"
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr "Infini"
 
-#: extension.js:753
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: extension.js:760
 msgid "Caffeine enabled"
 msgstr "Caféine est activé"
 
-#: extension.js:755
+#: extension.js:762
 #, fuzzy
 msgid "Night Light paused"
 msgstr "Mode nuit suspendu"
 
-#: extension.js:760
+#: extension.js:767
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caféine est activé"
 
-#: extension.js:762
+#: extension.js:769
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "Mode nuit réactivé"
@@ -179,7 +183,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr "Commute le Mode nuit en fonction de l’état de Caféine"
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "Autoriser la mise en veille de l'écran seulement"
 
@@ -202,7 +206,7 @@ msgid "Shortcut"
 msgstr "Raccourci"
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr "Raccourci clavier"
 
@@ -213,10 +217,6 @@ msgstr "Utiliser Retour arrière pour effacer"
 #: preferences/generalPage.js:217
 msgid "Set to "
 msgstr "Réglé sur "
-
-#: preferences/generalPage.js:217
-msgid " minutes"
-msgstr ""
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
@@ -243,102 +243,103 @@ msgid "Store caffeine user state"
 msgstr "Enregistrer l’état utilisateur de Caféine"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
-msgstr "Démarrer le minuteur"
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
 msgid "Specify time (minutes) for the timer countdown"
 msgstr "Durée du minuteur (en minutes)"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
 #, fuzzy
 msgid "Specify index of duration range for the timer"
 msgstr "Index de selection des durées du minuteur"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr "Rétablir l’état utilisateur de Caféine"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr "Afficher l’indicateur"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
 msgstr "Afficher Caféine dans la barre supérieure"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
 msgstr "Afficher les notifications"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr "Afficher les notifications si activé/désactivé"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr "Afficher le minuteur"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Afficher le minuteur si activé/désactivé"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "Activer lorsqu’une application est en plein écran"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr "Contrôle du Mode nuit"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 "Définir la manière dont Caféine interagit avec les réglages du Mode nuit."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Activer les notifications quand Caféine est activé ou désactivé"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 #, fuzzy
 msgid "Trigger App control mode"
 msgstr "Contrôle du Mode nuit"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr "Sélection de la méthode de déclenchement par les applications"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr "Raccourci pour commuter Caféine."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr "Largeur par défaut de la fenêtre de préférences"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr "Hauteur par défaut de la fenêtre de préférences"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr "Position relative de l’icône dans le menu indicator"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
-msgstr "Position réel de l’icône dans le menu indicator (comprend les icônes invisibles)"
+msgstr ""
+"Position réel de l’icône dans le menu indicator (comprend les icônes "
+"invisibles)"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr "Index du dernier élément dans le menu indicator"
+
+#~ msgid "Start Timer countdown"
+#~ msgstr "Démarrer le minuteur"
 
 #~ msgid "Auto suspend and screensaver disabled"
 #~ msgstr "Mise en veille et écran de veille désactivés"

--- a/caffeine@patapon.info/locale/hu/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/hu/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2018-06-22 21:22+0200\n"
 "Last-Translator: Kardos László <lacesz@NOSPAM@ox dot io>\n"
 "Language-Team: \n"
@@ -12,27 +12,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: extension.js:102
+#: extension.js:101
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:753
-msgid "Caffeine enabled"
-msgstr ""
-
-#: extension.js:755
-msgid "Night Light paused"
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
 msgstr ""
 
 #: extension.js:760
-msgid "Caffeine disabled"
+msgid "Caffeine enabled"
 msgstr ""
 
 #: extension.js:762
+msgid "Night Light paused"
+msgstr ""
+
+#: extension.js:767
+msgid "Caffeine disabled"
+msgstr ""
+
+#: extension.js:769
 msgid "Night Light resumed"
 msgstr ""
 
@@ -170,7 +174,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr "Együtt kapcsolja az éjszakai fényt a koffein állapotával"
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
@@ -193,7 +197,7 @@ msgid "Shortcut"
 msgstr "Parancsikon átváltása"
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr "Parancsikon átváltása"
 
@@ -203,10 +207,6 @@ msgstr "A törléshez használja a Backspace gombot"
 
 #: preferences/generalPage.js:217
 msgid "Set to "
-msgstr ""
-
-#: preferences/generalPage.js:217
-msgid " minutes"
 msgstr ""
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
@@ -234,97 +234,93 @@ msgid "Store caffeine user state"
 msgstr "Caffeine felhasználói állapot tárolása"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
+msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
-msgid "Specify time (minutes) for the timer countdown"
-msgstr ""
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
 msgid "Specify index of duration range for the timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr "Caffeine állapot visszaállítása"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr "Megjenelnítés az indikátoron"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
 msgstr "Indikátor megjelenítése a panelen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
 msgstr "Értesítések mutatása"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr "Értesítések mutatásának engedélyezése/tiltása"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Értesítések mutatásának engedélyezése/tiltása"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "Engedélyezés, ha teljes képernyős alkalmazás fut"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Értesítések mutatásának engedélyezése/tiltása"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/it_IT/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/it_IT/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2022-05-09 16:53+0200\n"
 "Last-Translator: Simone Esposito <simoespo159@gmail.com>\n"
 "Language-Team: Giuseppe Pignataro (Fastbyte01) <rogepix@gmail.com>\n"
@@ -17,29 +17,33 @@ msgstr ""
 "X-Generator: Poedit 2.0.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:102
+#: extension.js:101
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr "Infinito"
 
-#: extension.js:753
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: extension.js:760
 msgid "Caffeine enabled"
 msgstr "Caffeine aktiviert"
 
-#: extension.js:755
+#: extension.js:762
 #, fuzzy
 msgid "Night Light paused"
 msgstr "Modalità di controllo della modalità notturna"
 
-#: extension.js:760
+#: extension.js:767
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine aktiviert"
 
-#: extension.js:762
+#: extension.js:769
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "Modalità di controllo della modalità notturna"
@@ -177,7 +181,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr "Attiva la modalità notturna insieme allo stato di caffeine"
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
@@ -199,7 +203,7 @@ msgid "Shortcut"
 msgstr ""
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
@@ -209,10 +213,6 @@ msgstr ""
 
 #: preferences/generalPage.js:217
 msgid "Set to "
-msgstr ""
-
-#: preferences/generalPage.js:217
-msgid " minutes"
 msgstr ""
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
@@ -240,100 +240,96 @@ msgid "Store caffeine user state"
 msgstr "Salva lo stato di caffeine dell'utente"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
+msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
-msgid "Specify time (minutes) for the timer countdown"
-msgstr ""
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
 msgid "Specify index of duration range for the timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr "Ripristina lo stato di caffeine"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr "Mostra indicatore"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
 msgstr "Mostra indicatore nel pannello in alto"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
 msgstr "Mostra notifiche"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr "Mostra notifiche quando abilitato/disabilitato"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Mostra notifiche quando abilitato/disabilitato"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "Abilita quando è avviata una applicazione a schermo intero"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr "Modalità di controllo della modalità notturna"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 "Imposta il modo in cui caffeine interagisce con l'impostazione della "
 "Modalità notturna."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Mostra notifiche quando abilitato/disabilitato"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 #, fuzzy
 msgid "Trigger App control mode"
 msgstr "Modalità di controllo della modalità notturna"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/ja/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/ja/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2017-05-05 22:28+0900\n"
 "Last-Translator: Jean-Philippe Braun <eon@patapon.info>\n"
 "Language-Team: French\n"
@@ -17,28 +17,32 @@ msgstr ""
 "X-Generator: Poedit 2.0.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:102
+#: extension.js:101
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:753
-msgid "Caffeine enabled"
-msgstr "Caféine est activé"
-
-#: extension.js:755
-msgid "Night Light paused"
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
 msgstr ""
 
 #: extension.js:760
+msgid "Caffeine enabled"
+msgstr "Caféine est activé"
+
+#: extension.js:762
+msgid "Night Light paused"
+msgstr ""
+
+#: extension.js:767
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caféine est activé"
 
-#: extension.js:762
+#: extension.js:769
 msgid "Night Light resumed"
 msgstr ""
 
@@ -171,7 +175,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
@@ -192,7 +196,7 @@ msgid "Shortcut"
 msgstr ""
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
@@ -202,10 +206,6 @@ msgstr ""
 
 #: preferences/generalPage.js:217
 msgid "Set to "
-msgstr ""
-
-#: preferences/generalPage.js:217
-msgid " minutes"
 msgstr ""
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
@@ -230,95 +230,91 @@ msgid "Store caffeine user state"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
+msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
-msgid "Specify time (minutes) for the timer countdown"
-msgstr ""
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
 msgid "Specify index of duration range for the timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
 msgstr "Caffeine をトップバーに表示する"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
 msgstr "通知を有効にする"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show timer when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "フルスクリーンアプリケーション実行時に有効にする"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/ko/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/ko/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2022-09-10 10:53+0900\n"
 "Last-Translator: kuroehanako <kmj10727@gmail.com>\n"
 "Language-Team: \n"
@@ -15,28 +15,32 @@ msgstr ""
 "X-Poedit-Basepath: ../../gnome-shell-extension-caffeine-master\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: extension.js:102
+#: extension.js:101
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:753
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: extension.js:760
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:755
+#: extension.js:762
 #, fuzzy
 msgid "Night Light paused"
 msgstr "야간 모드를 멈춥니"
 
-#: extension.js:760
+#: extension.js:767
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:762
+#: extension.js:769
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "야간 모드를 다시 켭니"
@@ -167,7 +171,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr "카페인의 상태에 맞춰 야간 모드를 제어합니다."
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
@@ -189,7 +193,7 @@ msgid "Shortcut"
 msgstr ""
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
@@ -199,10 +203,6 @@ msgstr ""
 
 #: preferences/generalPage.js:217
 msgid "Set to "
-msgstr ""
-
-#: preferences/generalPage.js:217
-msgid " minutes"
 msgstr ""
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
@@ -228,98 +228,94 @@ msgid "Store caffeine user state"
 msgstr "카페인 사용자 상태를 저장"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
+msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
-msgid "Specify time (minutes) for the timer countdown"
-msgstr ""
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
 msgid "Specify index of duration range for the timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr "카페인 상태를 복원"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr "인디케이터 표시"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
 msgstr "상단 패널에 인디케이터 표시"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
 msgstr "알림 표시"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr "카페인을 켜고 끌 때마다 알림 표시"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "카페인을 켜고 끌 때마다 알림 표시"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "전체 화면 프로그램을 실행할 시 카페인 활성화"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr "야간 모드 제어 모드"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr "카페인 설정을 야간 모드 설정에 연동시킵니다."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "카페인을 켜고 끌 때마다 알림을 표시합니다."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 #, fuzzy
 msgid "Trigger App control mode"
 msgstr "야간 모드 제어 모드"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/nl/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/nl/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2023-02-07 14:23+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch\n"
@@ -17,27 +17,31 @@ msgstr ""
 "X-Generator: Poedit 3.2.2\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:102
+#: extension.js:101
 msgid "Caffeine timer"
 msgstr "Caffeine-tijdklok"
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr "Onbeperkt"
 
-#: extension.js:753
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: extension.js:760
 msgid "Caffeine enabled"
 msgstr "Caffeine is ingeschakeld"
 
-#: extension.js:755
+#: extension.js:762
 msgid "Night Light paused"
 msgstr "Nachtlicht is onderbroken"
 
-#: extension.js:760
+#: extension.js:767
 msgid "Caffeine disabled"
 msgstr "Caffeine is uitgeschakeld"
 
-#: extension.js:762
+#: extension.js:769
 msgid "Night Light resumed"
 msgstr "Nachtlicht is hervat"
 
@@ -164,7 +168,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr "Schakel nachtlicht tegelijk met Caffeine in/uit"
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "Scherm uitschakelen"
 
@@ -185,7 +189,7 @@ msgid "Shortcut"
 msgstr "Sneltoets"
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr "Aan-/Uitsneltoets"
 
@@ -195,10 +199,6 @@ msgstr "Druk op backspace om te wissen"
 
 #: preferences/generalPage.js:217
 msgid "Set to "
-msgstr ""
-
-#: preferences/generalPage.js:217
-msgid " minutes"
 msgstr ""
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
@@ -225,90 +225,86 @@ msgid "Store caffeine user state"
 msgstr "Huidige status bewaren"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
-msgstr "Tijdklok inschakelen"
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
 msgid "Specify time (minutes) for the timer countdown"
 msgstr "Geef aan hoelang de tijdklok dient af te tellen (in minuten)"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
 #, fuzzy
 msgid "Specify index of duration range for the timer"
 msgstr "Geef aan hoelang de tijdklok dient af te tellen (in minuten)"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr "Vorige status herstellen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr "Indicator tonen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
 msgstr "Toon de indicator op de bovenbalk"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
 msgstr "Meldingen tonen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr "Toon meldingen als Caffeine wordt in- of uitgeschakeld"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr "Tijdklok tonen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show timer when enabled/disabled"
 msgstr "Toon een tijdklok na in- of uitschakelen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "Inschakelen als een toepassing de schermvullende modus gebruikt"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr "Nachtlichtbediening"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr "Geef aan hoe Caffeine dient om te gaan met de nachtlichtinstelling."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Schakel het scherm uit als Caffeine wordt ingeschakeld."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
 msgstr "Aan-/Uitbedieningsmodus"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr "Stel de aan-/uitmethode van toepassingen in."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr "Sneltoets om Caffeine aan/uit te zetten."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr "Standaardbreedte van het voorkeurenvenster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr "Standaardhoogte van het voorkeurenvenster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr "Zichtbare locatieverschuiving van het pictogram in het indicatormenu"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
@@ -316,9 +312,12 @@ msgstr ""
 "Daadwerkelijke locatieverschuiving van het pictogram in het indicatormenu, "
 "inclusief het niet-getoonde"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr "Vorige itemlocatie in indicatormenu"
+
+#~ msgid "Start Timer countdown"
+#~ msgstr "Tijdklok inschakelen"
 
 #~ msgid "Auto suspend and screensaver disabled"
 #~ msgstr ""

--- a/caffeine@patapon.info/locale/pl/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/pl/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2016-10-02 17:24+0100\n"
 "Last-Translator: Piotr Wittchen <piotr@wittchen.biz.pl>\n"
 "Language-Team: Polish\n"
@@ -17,28 +17,32 @@ msgstr ""
 "X-Generator: Vim\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:102
+#: extension.js:101
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:753
-msgid "Caffeine enabled"
-msgstr "Caffeine włączone"
-
-#: extension.js:755
-msgid "Night Light paused"
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
 msgstr ""
 
 #: extension.js:760
+msgid "Caffeine enabled"
+msgstr "Caffeine włączone"
+
+#: extension.js:762
+msgid "Night Light paused"
+msgstr ""
+
+#: extension.js:767
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine włączone"
 
-#: extension.js:762
+#: extension.js:769
 msgid "Night Light resumed"
 msgstr ""
 
@@ -170,7 +174,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
@@ -191,7 +195,7 @@ msgid "Shortcut"
 msgstr ""
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
@@ -201,10 +205,6 @@ msgstr ""
 
 #: preferences/generalPage.js:217
 msgid "Set to "
-msgstr ""
-
-#: preferences/generalPage.js:217
-msgid " minutes"
 msgstr ""
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
@@ -230,97 +230,93 @@ msgid "Store caffeine user state"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
+msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
-msgid "Specify time (minutes) for the timer countdown"
-msgstr ""
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
 msgid "Specify index of duration range for the timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 #, fuzzy
 msgid "Show the indicator on the top panel"
 msgstr "Pokazuj Caffeine w górnym panelu"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 #, fuzzy
 msgid "Show notifications"
 msgstr "Włącz notyfikacje"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show timer when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "Włącz kiedy aplikacja jest uruchomiona w trybie pełnoekranowym"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/pt_BR/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/pt_BR/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2020-02-25 20:16-0300\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
 "Language-Team: Brazilian Portuguese <gnome-pt_br-list@gnome.org>\n"
@@ -22,28 +22,32 @@ msgstr ""
 "X-Generator: Gtranslator 3.32.0\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:102
+#: extension.js:101
 msgid "Caffeine timer"
 msgstr "Temporizador do Caffeine"
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr "Infinito"
 
-#: extension.js:753
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: extension.js:760
 msgid "Caffeine enabled"
 msgstr "Caffeine ativado"
 
-#: extension.js:755
+#: extension.js:762
 msgid "Night Light paused"
 msgstr "Luz Noturna pausado"
 
-#: extension.js:760
+#: extension.js:767
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine desativado"
 
-#: extension.js:762
+#: extension.js:769
 msgid "Night Light resumed"
 msgstr "Luz Noturna resumido"
 
@@ -178,7 +182,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr "Alternar Luz Noturna junto do estado do Caffeine"
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "Permitir tela desligada"
 
@@ -200,7 +204,7 @@ msgid "Shortcut"
 msgstr "Atalho"
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr "Atalho para alternar"
 
@@ -210,10 +214,6 @@ msgstr "Use Backspace para limpar"
 
 #: preferences/generalPage.js:217
 msgid "Set to "
-msgstr ""
-
-#: preferences/generalPage.js:217
-msgid " minutes"
 msgstr ""
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
@@ -241,101 +241,100 @@ msgid "Store caffeine user state"
 msgstr "Armazenar estado do caffeine do usuário"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
-msgstr "Iniciar a contagem regressiva"
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
 msgid "Specify time (minutes) for the timer countdown"
 msgstr "Especifique o tempo do temporizador em minutos"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
 #, fuzzy
 msgid "Specify index of duration range for the timer"
 msgstr "Especifique o tempo do temporizador em minutos"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr "Restaurar estado do caffeine"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr "Mostrar indicador"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
 msgstr "Mostrar o indicador no painel superior"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
 msgstr "Mostrar notificações"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr "Mostra notificações quando ativado/desativado"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr "Mostrar temporizador"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Mostra notificações quando ativado/desativado"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "Ativar enquanto um aplicativo em tela cheia estiver executando"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr "Modo de controle da Luz Noturna"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 "Configure a maneira que o Caffeine interage com a configuração da Luz Noturna"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Mostra notificações quando ativado/desativado"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
 msgstr "Modo de controle do Gatilho de Aplicativos"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr "Configure o metodo de gatilho para aplicativos"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr "Atalho para alterar o Caffeine"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr "Largura padrão para a janela de configurações"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr "Altura padrão para a janela de configurações"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr "Deslocamento visível da posição do icone"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr "Último índice do icone do menu indicador"
+
+#~ msgid "Start Timer countdown"
+#~ msgstr "Iniciar a contagem regressiva"
 
 #~ msgid "Auto suspend and screensaver disabled"
 #~ msgstr "Suspensão e proteção de tela automáticas desativadas"

--- a/caffeine@patapon.info/locale/pt_PT/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/pt_PT/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2016-12-02 10:01+0100\n"
 "Last-Translator: Steeven Lopes <steevenlopes@outlook.com>\n"
 "Language-Team: Portuguese\n"
@@ -17,28 +17,32 @@ msgstr ""
 "X-Generator: Poedit 1.6.10\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:102
+#: extension.js:101
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:753
-msgid "Caffeine enabled"
-msgstr "Caffeine ativado"
-
-#: extension.js:755
-msgid "Night Light paused"
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
 msgstr ""
 
 #: extension.js:760
+msgid "Caffeine enabled"
+msgstr "Caffeine ativado"
+
+#: extension.js:762
+msgid "Night Light paused"
+msgstr ""
+
+#: extension.js:767
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine ativado"
 
-#: extension.js:762
+#: extension.js:769
 msgid "Night Light resumed"
 msgstr ""
 
@@ -170,7 +174,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
@@ -191,7 +195,7 @@ msgid "Shortcut"
 msgstr ""
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
@@ -201,10 +205,6 @@ msgstr ""
 
 #: preferences/generalPage.js:217
 msgid "Set to "
-msgstr ""
-
-#: preferences/generalPage.js:217
-msgid " minutes"
 msgstr ""
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
@@ -230,97 +230,93 @@ msgid "Store caffeine user state"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
+msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
-msgid "Specify time (minutes) for the timer countdown"
-msgstr ""
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
 msgid "Specify index of duration range for the timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 #, fuzzy
 msgid "Show the indicator on the top panel"
 msgstr "Mostrar Caffeine no painel superior"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 #, fuzzy
 msgid "Show notifications"
 msgstr "Ativar notificações"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show timer when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "Ativar quando uma aplicação estiver a correr no modo ecrã inteiro"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/ru/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/ru/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2022-02-08 13:07+0300\n"
 "Last-Translator: Aleksandr Melman <Alexmelman88@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -17,28 +17,32 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:102
+#: extension.js:101
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:753
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
+msgstr ""
+
+#: extension.js:760
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:755
+#: extension.js:762
 #, fuzzy
 msgid "Night Light paused"
 msgstr "Ночная подсветка"
 
-#: extension.js:760
+#: extension.js:767
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:762
+#: extension.js:769
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "Ночная подсветка"
@@ -170,7 +174,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr "Переключение ночной подсветки вместе с состоянием Кофеина"
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
@@ -192,7 +196,7 @@ msgid "Shortcut"
 msgstr ""
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
@@ -202,10 +206,6 @@ msgstr ""
 
 #: preferences/generalPage.js:217
 msgid "Set to "
-msgstr ""
-
-#: preferences/generalPage.js:217
-msgid " minutes"
 msgstr ""
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
@@ -231,98 +231,94 @@ msgid "Store caffeine user state"
 msgstr "Сохранить пользовательский выбор"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
+msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
-msgid "Specify time (minutes) for the timer countdown"
-msgstr ""
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
 msgid "Specify index of duration range for the timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr "Восстановить состояние приложения"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr "Показывать индикатор"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
 msgstr "Показать индикатор на верхней панели"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
 msgstr "Показывать уведомления"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr "Показывать уведомление, когда включено/выключено"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Показывать уведомление, когда включено/выключено"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "Включать, когда запущено полноэкранное приложение"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr "Режим управления ночной подсветкой"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr "Настроить взаимодействие Кофеина с параметром \"Ночная подсветка\"."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Включить уведомления о включении или отключении Кофеина"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 #, fuzzy
 msgid "Trigger App control mode"
 msgstr "Режим управления ночной подсветкой"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/sk/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/sk/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2015-01-16 10:24+0100\n"
 "Last-Translator: Dušan Kazik <prescott66@gmail.com>\n"
 "Language-Team: Slovak\n"
@@ -17,28 +17,32 @@ msgstr ""
 "X-Generator: Poedit 1.7.3\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:102
+#: extension.js:101
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:753
-msgid "Caffeine enabled"
-msgstr "Caffeine aktiviert"
-
-#: extension.js:755
-msgid "Night Light paused"
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
 msgstr ""
 
 #: extension.js:760
+msgid "Caffeine enabled"
+msgstr "Caffeine aktiviert"
+
+#: extension.js:762
+msgid "Night Light paused"
+msgstr ""
+
+#: extension.js:767
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine aktiviert"
 
-#: extension.js:762
+#: extension.js:769
 msgid "Night Light resumed"
 msgstr ""
 
@@ -170,7 +174,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
@@ -191,7 +195,7 @@ msgid "Shortcut"
 msgstr ""
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
@@ -201,10 +205,6 @@ msgstr ""
 
 #: preferences/generalPage.js:217
 msgid "Set to "
-msgstr ""
-
-#: preferences/generalPage.js:217
-msgid " minutes"
 msgstr ""
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
@@ -230,97 +230,93 @@ msgid "Store caffeine user state"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
+msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
-msgid "Specify time (minutes) for the timer countdown"
-msgstr ""
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
 msgid "Specify index of duration range for the timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 #, fuzzy
 msgid "Show the indicator on the top panel"
 msgstr "Zobraziť Caffeine v hornej lište"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 #, fuzzy
 msgid "Show notifications"
 msgstr "Povoliť oznámenia"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show timer when enabled/disabled"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "Povoliť, keď je spustená aplikácia v režime na celú obrazovku"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/sv/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/sv/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2018-04-04 20:35+0200\n"
 "Last-Translator: Morgan Antonsson <morgan.antonsson@gmail.com>\n"
 "Language-Team: \n"
@@ -11,27 +11,31 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: extension.js:102
+#: extension.js:101
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:753
-msgid "Caffeine enabled"
-msgstr ""
-
-#: extension.js:755
-msgid "Night Light paused"
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
 msgstr ""
 
 #: extension.js:760
-msgid "Caffeine disabled"
+msgid "Caffeine enabled"
 msgstr ""
 
 #: extension.js:762
+msgid "Night Light paused"
+msgstr ""
+
+#: extension.js:767
+msgid "Caffeine disabled"
+msgstr ""
+
+#: extension.js:769
 msgid "Night Light resumed"
 msgstr ""
 
@@ -166,7 +170,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
@@ -188,7 +192,7 @@ msgid "Shortcut"
 msgstr ""
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
@@ -198,10 +202,6 @@ msgstr ""
 
 #: preferences/generalPage.js:217
 msgid "Set to "
-msgstr ""
-
-#: preferences/generalPage.js:217
-msgid " minutes"
 msgstr ""
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
@@ -227,97 +227,93 @@ msgid "Store caffeine user state"
 msgstr "Spara caffeines användarstatus"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
+msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
-msgid "Specify time (minutes) for the timer countdown"
-msgstr ""
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
 msgid "Specify index of duration range for the timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr "Återställ caffeine-status"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr "Visa indikator"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
 msgstr "Visa indikator i panelen"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
 msgstr "Visa notifieringar"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr "Visa notifieringar vid aktivering/inaktivering"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Visa notifieringar vid aktivering/inaktivering"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "Aktivera när ett program använder helskärmsläget"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Visa notifieringar vid aktivering/inaktivering"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/tr/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/tr/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2019-03-21 06:48+0300\n"
 "Last-Translator: Serdar Sağlam <teknomobil@yandex.com>\n"
 "Language-Team: Turkish <gnome-turk@gnome.org>\n"
@@ -18,28 +18,32 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Generator: Gtranslator 3.32.0\n"
 
-#: extension.js:102
+#: extension.js:101
 msgid "Caffeine timer"
 msgstr ""
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:753
-msgid "Caffeine enabled"
-msgstr "Caffeine aktif"
-
-#: extension.js:755
-msgid "Night Light paused"
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
 msgstr ""
 
 #: extension.js:760
+msgid "Caffeine enabled"
+msgstr "Caffeine aktif"
+
+#: extension.js:762
+msgid "Night Light paused"
+msgstr ""
+
+#: extension.js:767
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caffeine aktif"
 
-#: extension.js:762
+#: extension.js:769
 msgid "Night Light resumed"
 msgstr ""
 
@@ -174,7 +178,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
@@ -196,7 +200,7 @@ msgid "Shortcut"
 msgstr ""
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
@@ -206,10 +210,6 @@ msgstr ""
 
 #: preferences/generalPage.js:217
 msgid "Set to "
-msgstr ""
-
-#: preferences/generalPage.js:217
-msgid " minutes"
 msgstr ""
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
@@ -236,97 +236,93 @@ msgid "Store caffeine user state"
 msgstr "Kafein kullanıcı durumunu sakla"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
+msgid "Specify time (minutes) for the timer countdown"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
-msgid "Specify time (minutes) for the timer countdown"
-msgstr ""
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
 msgid "Specify index of duration range for the timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr "Kafein durumunu geri yükle"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr "Göstergeyi göster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
 msgstr "Göstergeyi üst panelde göster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
 msgstr "Bildirimleri göster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr "Aktif/Pasif olduğunda bildirimleri göster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 #, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Aktif/Pasif olduğunda bildirimleri göster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "Tam ekran uygulama çalıştırıldığı zaman aktif olacaktır"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Aktif/Pasif olduğunda bildirimleri göster"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/zh_CN/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/zh_CN/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-11 23:33+0000\n"
+"POT-Creation-Date: 2023-03-22 12:33+0100\n"
 "PO-Revision-Date: 2022-06-30 11:54-0400\n"
 "Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <debian-l10n-chinese@lists.debian.org>\n"
@@ -17,27 +17,31 @@ msgstr ""
 "X-Generator: Poedit 3.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:102
+#: extension.js:101
 msgid "Caffeine timer"
 msgstr "Caffeine 定时器"
 
-#: extension.js:218
+#: extension.js:216
 msgid "Infinite"
 msgstr "持续"
 
-#: extension.js:753
+#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+msgid " minutes"
+msgstr " 分钟"
+
+#: extension.js:760
 msgid "Caffeine enabled"
 msgstr "Caffeine 已开启"
 
-#: extension.js:755
+#: extension.js:762
 msgid "Night Light paused"
 msgstr "夜灯已暂停"
 
-#: extension.js:760
+#: extension.js:767
 msgid "Caffeine disabled"
 msgstr "Caffeine 已关闭"
 
-#: extension.js:762
+#: extension.js:769
 msgid "Night Light resumed"
 msgstr "夜灯已恢复"
 
@@ -162,7 +166,7 @@ msgid "Toggles the night light together with Caffeine's state"
 msgstr "随 Caffeine 的状态切换夜灯"
 
 #: preferences/generalPage.js:102
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "允许屏幕保护"
 
@@ -183,7 +187,7 @@ msgid "Shortcut"
 msgstr "快捷键"
 
 #: preferences/generalPage.js:175
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr "修改快捷键"
 
@@ -194,10 +198,6 @@ msgstr "使用退格来清除"
 #: preferences/generalPage.js:217
 msgid "Set to "
 msgstr "设置到 "
-
-#: preferences/generalPage.js:217
-msgid " minutes"
-msgstr " 分钟"
 
 #: preferences/generalPage.js:264 preferences/generalPage.js:296
 msgid "New accelerator…"
@@ -221,97 +221,96 @@ msgid "Store caffeine user state"
 msgstr "保存 caffeine 状态"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
-msgid "Start Timer countdown"
-msgstr "开始计时器倒计时"
-
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
 msgid "Specify time (minutes) for the timer countdown"
 msgstr "指定计时器倒计时的时间 (分钟)"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:48
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
 msgid "Specify index of duration range for the timer"
 msgstr "指定计时器的持续时间"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
 msgstr "恢复 caffeine 状态"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
 msgstr "显示指示器"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
 msgstr "在顶部面板显示指示器"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
 msgstr "显示通知"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
 msgstr "启用/禁用时显示通知"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
 msgstr "显示计时器"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
 msgid "Show timer when enabled/disabled"
 msgstr "启用/禁用时显示计时器"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:67
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:68
 msgid "Enable when a fullscreen application is running"
 msgstr "运行全屏程序时自动启动"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:72
 msgid "Night Light control mode"
 msgstr "夜灯控制模式"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr "设置 Caffeine 和夜灯设置交互的方式。"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "允许在 Caffeine 启用时关闭屏幕"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
 msgstr "吃法应用控制模式"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:83
 msgid "Set the trigger method for apps."
 msgstr "设置应用的触发方式."
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:93
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
 msgstr "切换 Caffeine 的快捷键"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:97
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
 msgstr "首选项窗口的默认宽度"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:101
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:96
 msgid "Default height for the preferences window"
 msgstr "首选项窗口的默认高度"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:105
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
 msgstr "菜单中状态指示器的位置偏移"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:109
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr "菜单中状态指示器的真实位置偏移，包括不可见的"
 
-#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:113
+#: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
 msgstr "菜单中的最后一项"
+
+#~ msgid "Start Timer countdown"
+#~ msgstr "开始计时器倒计时"
 
 #~ msgid "Auto suspend and screensaver disabled"
 #~ msgstr "自动挂起与屏幕保护程序已禁用"

--- a/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
+++ b/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
@@ -32,11 +32,6 @@
         <summary>Store caffeine user state</summary>
         <description></description>
     </key>
-    <key type="b" name="countdown-timer-enabled">
-        <default>false</default>
-        <summary>Start Timer countdown</summary>
-        <description></description>
-    </key>
     <key type="i" name="countdown-timer">
         <default>0</default>
         <summary>Specify time (minutes) for the timer countdown</summary>


### PR DESCRIPTION
### Timer behavior
To keep design consistent with official QuickSetting toggle like `Power Profiles`, I propose that Caffeine remember the last timer option selected (as we discussed in #234). 
It will be always a timer option selected: when changing duration range in settings, the selection will reset to `infinite`.

### Gnome 44: new Subtitle

Gnome 44 introduce a new subtitle label and last version of Caffeine already using it to show countdown when timer is enable.
With this change, it would also make sens to show which timer option is selected in toggle subtitle when Caffeine is disable. Subtitle is disable when `infinite` is selected.

![Caffeine_timer_subtitle](https://user-images.githubusercontent.com/83842133/226759188-bef2582e-a355-42de-958b-94ba36c222b5.png)

I also think it can be great to see which app is enabling Caffeine:

![Caffeine_app_subtitle](https://user-images.githubusercontent.com/83842133/226759210-7b890658-66bf-4b1d-914f-558ac1e06690.png)

When having multiple active apps that trigger Caffeine, it will show only the last opened. Then, the name will be updated or removed as apps are closed one by one.

