### PR TITLE
Translate 'Caffeine' in QuickSettings

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -98,8 +98,6 @@ const DBusSessionManagerInhibitorIface = '<node>\
 const DBusSessionManagerInhibitorProxy = Gio.DBusProxy.makeProxyWrapper(DBusSessionManagerInhibitorIface);
 
 const IndicatorName = 'Caffeine';
-const IndicatorLabel = _('Caffeine');
-const TimerMenuName = _('Caffeine timer');
 const DisabledIcon = 'my-caffeine-off-symbolic';
 const EnabledIcon = 'my-caffeine-on-symbolic';
 const TimerMenuIcon = 'stopwatch-symbolic';
@@ -159,7 +157,7 @@ class CaffeineToggle extends QuickSettings.QuickMenuToggle {
             // The 'label' property was renamed to 'title' in GNOME 44 but quick settings have otherwise 
             // not been changed. The below line allows support for both GNOME 43 and 44+ by using the 
             // appropriate property name based on the GNOME version.
-            [ShellVersion >= 44 ? 'title' : 'label']: IndicatorLabel,
+            [ShellVersion >= 44 ? 'title' : 'label']: _('Caffeine'),
             toggleMode: true,
         });
 
@@ -176,7 +174,7 @@ class CaffeineToggle extends QuickSettings.QuickMenuToggle {
         this._iconName();
 
         // Menu
-        this.menu.setHeader(this.finalTimerMenuIcon, TimerMenuName, null);
+        this.menu.setHeader(this.finalTimerMenuIcon, _('Caffeine timer'), null);
 
         // Add elements
         this._itemsSection = new PopupMenu.PopupMenuSection();
@@ -616,7 +614,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
 
     _updateLabelTimer(text) {
         this._timerLabel.text = text;
-        this._caffeineToggle.menu.setHeader(this._caffeineToggle.finalTimerMenuIcon, TimerMenuName, text);
+        this._caffeineToggle.menu.setHeader(this._caffeineToggle.finalTimerMenuIcon, _('Caffeine timer'), text);
         if (ShellVersion >= 44) {
             this._caffeineToggle.subtitle = text;    
         }   

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -98,6 +98,7 @@ const DBusSessionManagerInhibitorIface = '<node>\
 const DBusSessionManagerInhibitorProxy = Gio.DBusProxy.makeProxyWrapper(DBusSessionManagerInhibitorIface);
 
 const IndicatorName = 'Caffeine';
+const IndicatorLabel = _('Caffeine');
 const TimerMenuName = _('Caffeine timer');
 const DisabledIcon = 'my-caffeine-off-symbolic';
 const EnabledIcon = 'my-caffeine-on-symbolic';
@@ -158,7 +159,7 @@ class CaffeineToggle extends QuickSettings.QuickMenuToggle {
             // The 'label' property was renamed to 'title' in GNOME 44 but quick settings have otherwise 
             // not been changed. The below line allows support for both GNOME 43 and 44+ by using the 
             // appropriate property name based on the GNOME version.
-            [ShellVersion >= 44 ? 'title' : 'label']: IndicatorName,
+            [ShellVersion >= 44 ? 'title' : 'label']: IndicatorLabel,
             toggleMode: true,
         });
 

--- a/caffeine@patapon.info/locale/cs/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/cs/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2023-04-12 18:40+0200\n"
 "Last-Translator: Kryštof Černý <cleerline1mc@gmail.com>\n"
 "Language-Team: Czech\n"
@@ -17,35 +17,35 @@ msgstr ""
 "X-Generator: Poedit 3.2.2\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "Kofein"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "Časovač Kofein"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr "Nekonečně"
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr " minut"
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr "Kofein povolen"
 
-#: extension.js:768
+#: extension.js:766
 msgid "Night Light paused"
 msgstr "Noční světlo pozastaveno"
 
-#: extension.js:773
+#: extension.js:771
 msgid "Caffeine disabled"
 msgstr "Kofein zakázán"
 
-#: extension.js:775
+#: extension.js:773
 msgid "Night Light resumed"
 msgstr "Noční světlo obnoveno"
 
@@ -273,8 +273,7 @@ msgstr "Režim řízení Nočního světla"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
-msgstr ""
-"Nastavte způsob, kterým Kofein interaguje s nastavením Nočního světla."
+msgstr "Nastavte způsob, kterým Kofein interaguje s nastavením Nočního světla."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."

--- a/caffeine@patapon.info/locale/cs/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/cs/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2023-04-12 18:40+0200\n"
 "Last-Translator: Kryštof Černý <cleerline1mc@gmail.com>\n"
 "Language-Team: Czech\n"
@@ -18,30 +18,34 @@ msgstr ""
 "X-Poedit-SearchPath-0: ../../..\n"
 
 #: extension.js:101
-msgid "Caffeine timer"
-msgstr "Časovač Caffeine"
+msgid "Caffeine"
+msgstr "Kofein"
 
-#: extension.js:216
+#: extension.js:102
+msgid "Caffeine timer"
+msgstr "Časovač Kofein"
+
+#: extension.js:217
 msgid "Infinite"
 msgstr "Nekonečně"
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr " minut"
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
-msgstr "Caffeine povolen"
+msgstr "Kofein povolen"
 
-#: extension.js:762
+#: extension.js:768
 msgid "Night Light paused"
 msgstr "Noční světlo pozastaveno"
 
-#: extension.js:767
+#: extension.js:773
 msgid "Caffeine disabled"
-msgstr "Caffeine zakázán"
+msgstr "Kofein zakázán"
 
-#: extension.js:769
+#: extension.js:775
 msgid "Night Light resumed"
 msgstr "Noční světlo obnoveno"
 
@@ -67,11 +71,11 @@ msgstr "Režim aktivování"
 
 #: preferences/appsPage.js:58
 msgid "Apps trigger Caffeine mode"
-msgstr "Aplikace spustí režim Caffeine, když jsou"
+msgstr "Aplikace spustí režim Kofein, když jsou"
 
 #: preferences/appsPage.js:59
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Vybrat způsob, jakým aplikace aktivují Caffeine"
+msgstr "Vybrat způsob, jakým aplikace aktivují Kofein"
 
 #: preferences/appsPage.js:73
 msgid "Add"
@@ -79,7 +83,7 @@ msgstr "Přidat"
 
 #: preferences/appsPage.js:77
 msgid "Apps that trigger Caffeine"
-msgstr "Aplikace, které aktivují Caffeine"
+msgstr "Aplikace, které aktivují Kofein"
 
 #: preferences/displayPage.js:32 preferences/displayPage.js:42
 msgid "Display"
@@ -103,7 +107,7 @@ msgstr "Zobrazit indikátor stavu v horní liště"
 
 #: preferences/displayPage.js:52
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Povolit nebo zakázat ikonu Caffeine v horní liště"
+msgstr "Povolit nebo zakázat ikonu Kofein v horní liště"
 
 #: preferences/displayPage.js:63
 msgid "Show timer in top panel"
@@ -119,7 +123,7 @@ msgstr "Upozornění"
 
 #: preferences/displayPage.js:76
 msgid "Enable notifications when Caffeine is enabled or disabled"
-msgstr "Povolit upozornění, když je Caffeine povoleno nebo zakázáno"
+msgstr "Povolit upozornění, když je Kofein povoleno nebo zakázáno"
 
 #: preferences/displayPage.js:98
 msgid "Status indicator position"
@@ -163,7 +167,7 @@ msgstr "Pozastavit a obnovit Noční světlo"
 
 #: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
-msgstr "Přepne noční světlo spolu se stavem Caffeine"
+msgstr "Přepne noční světlo spolu se stavem Kofein"
 
 #: preferences/generalPage.js:102
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
@@ -172,7 +176,7 @@ msgstr "Povolit prázdnou obrazovku"
 
 #: preferences/generalPage.js:103
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "Povolit vypínání obrazovky s povoleným Caffeine"
+msgstr "Povolit vypínání obrazovky s povoleným Kofein"
 
 #: preferences/generalPage.js:118
 msgid "Timer"
@@ -214,11 +218,11 @@ msgstr "Seznam řetězců, každý obsahující id aplikace (název desktop soub
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 msgid "Store caffeine toggle state"
-msgstr "Uložit stav zapnutí caffeine"
+msgstr "Uložit stav zapnutí Kofein"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
-msgstr "Uložit uživatelský stav caffeine"
+msgstr "Uložit uživatelský stav Kofein"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
@@ -232,7 +236,7 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Obnovit stav caffeine"
+msgstr "Obnovit stav Kofein"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -270,11 +274,11 @@ msgstr "Režim řízení Nočního světla"
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
-"Nastavte způsob, kterým Caffeine interaguje s nastavením Nočního světla."
+"Nastavte způsob, kterým Kofein interaguje s nastavením Nočního světla."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
-msgstr "Povolit vypínání obrazovky s povoleným Caffeine."
+msgstr "Povolit vypínání obrazovky s povoleným Kofein."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
@@ -286,7 +290,7 @@ msgstr "Nastavit režim spuštění pro aplikace."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
-msgstr "Zkratka pro přepnutí Caffeine."
+msgstr "Zkratka pro přepnutí Kofein."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"

--- a/caffeine@patapon.info/locale/de/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/de/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2021-04-09 21:31-0400\n"
 "Last-Translator: WebSnke <websnke@tutanota.com>\n"
 "Language-Team: German\n"
@@ -17,35 +17,35 @@ msgstr ""
 "X-Generator: Poedit 2.4.2\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "Koffein"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "Koffein-Timer"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr "Unendlich"
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr " Minuten"
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr "Koffein aktiviert"
 
-#: extension.js:768
+#: extension.js:766
 msgid "Night Light paused"
 msgstr "Nachtmodus pausiert"
 
-#: extension.js:773
+#: extension.js:771
 msgid "Caffeine disabled"
 msgstr "Koffein deaktiviert"
 
-#: extension.js:775
+#: extension.js:773
 msgid "Night Light resumed"
 msgstr "Nachtmodus fortgesetzt"
 

--- a/caffeine@patapon.info/locale/de/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/de/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2021-04-09 21:31-0400\n"
 "Last-Translator: WebSnke <websnke@tutanota.com>\n"
 "Language-Team: German\n"
@@ -18,30 +18,34 @@ msgstr ""
 "X-Poedit-SearchPath-0: ../../..\n"
 
 #: extension.js:101
-msgid "Caffeine timer"
-msgstr "Caffeine-Timer"
+msgid "Caffeine"
+msgstr "Koffein"
 
-#: extension.js:216
+#: extension.js:102
+msgid "Caffeine timer"
+msgstr "Koffein-Timer"
+
+#: extension.js:217
 msgid "Infinite"
 msgstr "Unendlich"
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr " Minuten"
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
-msgstr "Caffeine aktiviert"
+msgstr "Koffein aktiviert"
 
-#: extension.js:762
+#: extension.js:768
 msgid "Night Light paused"
 msgstr "Nachtmodus pausiert"
 
-#: extension.js:767
+#: extension.js:773
 msgid "Caffeine disabled"
-msgstr "Caffeine deaktiviert"
+msgstr "Koffein deaktiviert"
 
-#: extension.js:769
+#: extension.js:775
 msgid "Night Light resumed"
 msgstr "Nachtmodus fortgesetzt"
 
@@ -67,11 +71,11 @@ msgstr ""
 
 #: preferences/appsPage.js:58
 msgid "Apps trigger Caffeine mode"
-msgstr "Anwendungen, die Caffeine aktivieren"
+msgstr "Anwendungen, die Koffein aktivieren"
 
 #: preferences/appsPage.js:59
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Wähle, wie Anwendungen Caffeine aktivieren"
+msgstr "Wähle, wie Anwendungen Koffein aktivieren"
 
 #: preferences/appsPage.js:73
 msgid "Add"
@@ -79,7 +83,7 @@ msgstr "Hinzufügen"
 
 #: preferences/appsPage.js:77
 msgid "Apps that trigger Caffeine"
-msgstr "Anwendungen, die Caffeine aktivieren"
+msgstr "Anwendungen, die Koffein aktivieren"
 
 #: preferences/displayPage.js:32 preferences/displayPage.js:42
 msgid "Display"
@@ -103,15 +107,15 @@ msgstr "Indikator-Icon in der oberen Leiste anzeigen"
 
 #: preferences/displayPage.js:52
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Aktiviert oder deaktiviert das Caffeine Icon in der oberen Leiste"
+msgstr "Aktiviert oder deaktiviert das Koffein Icon in der oberen Leiste"
 
 #: preferences/displayPage.js:63
 msgid "Show timer in top panel"
-msgstr "Caffeine in der oberen Leiste anzeigen"
+msgstr "Koffein in der oberen Leiste anzeigen"
 
 #: preferences/displayPage.js:64
 msgid "Enable or disable the timer in the top panel"
-msgstr "Aktiviert oder deaktiviert das Caffeine Icon in der oberen Leiste"
+msgstr "Aktiviert oder deaktiviert das Koffein Icon in der oberen Leiste"
 
 #: preferences/displayPage.js:75
 msgid "Notifications"
@@ -163,7 +167,7 @@ msgstr "Nachtmodus unterbrechen"
 
 #: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
-msgstr "Unterbricht den Nachtmodus wenn Caffeine aktiviert wird"
+msgstr "Unterbricht den Nachtmodus wenn Koffein aktiviert wird"
 
 #: preferences/generalPage.js:102
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
@@ -172,7 +176,7 @@ msgstr "Erlaube es, den Bildschirm auszuschalten"
 
 #: preferences/generalPage.js:103
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "Ausschalten des Bildschirms, wenn Caffeine an ist, erlauben"
+msgstr "Ausschalten des Bildschirms, wenn Koffein an ist, erlauben"
 
 #: preferences/generalPage.js:118
 msgid "Timer"
@@ -235,7 +239,7 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Caffeines Zustand wiederherstellen"
+msgstr "Koffein Zustand wiederherstellen"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -243,7 +247,7 @@ msgstr "Indikator anzeigen"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
-msgstr "Caffeine-Indikator in der oberen Leiste anzeigen"
+msgstr "Koffein-Indikator in der oberen Leiste anzeigen"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
@@ -276,7 +280,7 @@ msgstr "Lege fest, wie Caffein mit dem Nachtmodus umgeht."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
-msgstr "Ausschalten des Bildschirms, wenn Caffeine an ist, erlauben"
+msgstr "Ausschalten des Bildschirms, wenn Koffein an ist, erlauben"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
@@ -288,7 +292,7 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
-msgstr "Tastenkombination um Caffeine zu öffnen."
+msgstr "Tastenkombination um Koffein zu öffnen."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
@@ -349,7 +353,7 @@ msgstr ""
 #~ msgstr "Benachrichtigungen aktivieren"
 
 #~ msgid "Applications which enable Caffeine automatically"
-#~ msgstr "Anwendungen, welche Caffeine automatisch aktivieren"
+#~ msgstr "Anwendungen, welche Koffein automatisch aktivieren"
 
 #~ msgid "Create new matching rule"
 #~ msgstr "Neue Regel definieren"

--- a/caffeine@patapon.info/locale/es/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/es/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2015-11-28 21:06-0300\n"
 "Last-Translator: Sergio D. Márquez <marquez.sergio.d@gmail.com>\n"
 "Language-Team: Spanish\n"
@@ -17,37 +17,37 @@ msgstr ""
 "X-Generator: Poedit 1.8.6\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "Cafeína"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 #, fuzzy
 msgid "Caffeine timer"
 msgstr "Cafeína temporizador"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr "Infinito"
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr "Cafeína activado"
 
-#: extension.js:768
+#: extension.js:766
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:773
+#: extension.js:771
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Cafeína activado"
 
-#: extension.js:775
+#: extension.js:773
 msgid "Night Light resumed"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/es/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/es/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2015-11-28 21:06-0300\n"
 "Last-Translator: Sergio D. Márquez <marquez.sergio.d@gmail.com>\n"
 "Language-Team: Spanish\n"
@@ -18,32 +18,36 @@ msgstr ""
 "X-Poedit-SearchPath-0: ../../..\n"
 
 #: extension.js:101
+msgid "Caffeine"
+msgstr "Cafeína"
+
+#: extension.js:102
 #, fuzzy
 msgid "Caffeine timer"
-msgstr "Caffeine temporizador"
+msgstr "Cafeína temporizador"
 
-#: extension.js:216
+#: extension.js:217
 msgid "Infinite"
 msgstr "Infinito"
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
-msgstr "Caffeine activado"
+msgstr "Cafeína activado"
 
-#: extension.js:762
+#: extension.js:768
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:767
+#: extension.js:773
 #, fuzzy
 msgid "Caffeine disabled"
-msgstr "Caffeine activado"
+msgstr "Cafeína activado"
 
-#: extension.js:769
+#: extension.js:775
 msgid "Night Light resumed"
 msgstr ""
 
@@ -70,12 +74,12 @@ msgstr ""
 #: preferences/appsPage.js:58
 #, fuzzy
 msgid "Apps trigger Caffeine mode"
-msgstr "Aplicaciones que activan Caffeine"
+msgstr "Aplicaciones que activan Cafeína"
 
 #: preferences/appsPage.js:59
 #, fuzzy
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Aplicaciones que activan Caffeine"
+msgstr "Aplicaciones que activan Cafeína"
 
 #: preferences/appsPage.js:73
 msgid "Add"
@@ -83,7 +87,7 @@ msgstr "Agregar"
 
 #: preferences/appsPage.js:77
 msgid "Apps that trigger Caffeine"
-msgstr "Aplicaciones que activan Caffeine"
+msgstr "Aplicaciones que activan Cafeína"
 
 #: preferences/displayPage.js:32 preferences/displayPage.js:42
 msgid "Display"
@@ -104,22 +108,22 @@ msgstr "Nunca"
 #: preferences/displayPage.js:51
 #, fuzzy
 msgid "Show status indicator in top panel"
-msgstr "Mostrar Caffeine en el panel superior"
+msgstr "Mostrar Cafeína en el panel superior"
 
 #: preferences/displayPage.js:52
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Mostrar Caffeine en el panel superior"
+msgstr "Mostrar Cafeína en el panel superior"
 
 #: preferences/displayPage.js:63
 #, fuzzy
 msgid "Show timer in top panel"
-msgstr "Mostrar Caffeine en el panel superior"
+msgstr "Mostrar Cafeína en el panel superior"
 
 #: preferences/displayPage.js:64
 #, fuzzy
 msgid "Enable or disable the timer in the top panel"
-msgstr "Mostrar Caffeine en el panel superior"
+msgstr "Mostrar Cafeína en el panel superior"
 
 #: preferences/displayPage.js:75
 #, fuzzy
@@ -134,7 +138,7 @@ msgstr "Mostrar notificaciones de habilitado/deshabilitado"
 #: preferences/displayPage.js:98
 #, fuzzy
 msgid "Status indicator position"
-msgstr "Mostrar Caffeine en el panel superior"
+msgstr "Mostrar Cafeína en el panel superior"
 
 #: preferences/displayPage.js:99
 msgid "The position relative of indicator icon to other items"
@@ -235,11 +239,11 @@ msgstr ""
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 #, fuzzy
 msgid "Store caffeine toggle state"
-msgstr "Guardar estado de usuario de Caffeine"
+msgstr "Guardar estado de usuario de Cafeína"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
-msgstr "Guardar estado de usuario de Caffeine"
+msgstr "Guardar estado de usuario de Cafeína"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
@@ -253,7 +257,7 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Restablecer estado de Caffeine"
+msgstr "Restablecer estado de Cafeína"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -262,7 +266,7 @@ msgstr "Mostrar indicador"
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 #, fuzzy
 msgid "Show the indicator on the top panel"
-msgstr "Mostrar Caffeine en el panel superior"
+msgstr "Mostrar Cafeína en el panel superior"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 #, fuzzy
@@ -369,7 +373,7 @@ msgstr ""
 #~ msgstr "Activar las notificaciones"
 
 #~ msgid "Applications which enable Caffeine automatically"
-#~ msgstr "Aplicaciones que activan Caffeine automáticamente"
+#~ msgstr "Aplicaciones que activan Cafeína automáticamente"
 
 #~ msgid "Create new matching rule"
 #~ msgstr "Crear nueva regla"

--- a/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:01+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2022-10-07 16:40+0200\n"
 "Last-Translator: Pakaoraki <pakaoraki@gmx.com>\n"
 "Language-Team: French\n"
@@ -24,30 +24,34 @@ msgstr ""
 "X-Poedit-SearchPath-0: ../../..\n"
 
 #: extension.js:101
+msgid "Caffeine"
+msgstr "Caféine"
+
+#: extension.js:102
 msgid "Caffeine timer"
 msgstr "Caféine minuteur"
 
-#: extension.js:216
+#: extension.js:217
 msgid "Infinite"
 msgstr "Infini"
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr " minutes"
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
 msgstr "Caféine est activé"
 
-#: extension.js:762
+#: extension.js:768
 msgid "Night Light paused"
 msgstr "Mode nuit suspendu"
 
-#: extension.js:767
+#: extension.js:773
 msgid "Caffeine disabled"
 msgstr "Caféine est désactivé"
 
-#: extension.js:769
+#: extension.js:775
 msgid "Night Light resumed"
 msgstr "Mode nuit réactivé"
 
@@ -153,7 +157,8 @@ msgstr "Activer pour les applications en plein écran"
 
 #: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
-msgstr "Activer automatiquement lorsqu’une application entre en mode plein écran"
+msgstr ""
+"Activer automatiquement lorsqu’une application entre en mode plein écran"
 
 #: preferences/generalPage.js:78
 msgid "Remember state"
@@ -161,7 +166,9 @@ msgstr "Se souvenir de l’état"
 
 #: preferences/generalPage.js:79
 msgid "Remember the last state across sessions and reboots"
-msgstr "Se souvenir du dernier état au-delà des changements de session et redémarrages"
+msgstr ""
+"Se souvenir du dernier état au-delà des changements de session et "
+"redémarrages"
 
 #: preferences/generalPage.js:90
 msgid "Pause and resume Night Light"
@@ -277,7 +284,8 @@ msgstr "Contrôle du Mode nuit"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
-msgstr "Définir la manière dont Caféine interagit avec les réglages du Mode nuit."
+msgstr ""
+"Définir la manière dont Caféine interagit avec les réglages du Mode nuit."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."

--- a/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -25,7 +25,7 @@ msgstr ""
 
 #: extension.js:101
 msgid "Caffeine timer"
-msgstr "Caffeine minuteur"
+msgstr "Caféine minuteur"
 
 #: extension.js:216
 msgid "Infinite"
@@ -37,7 +37,7 @@ msgstr " minutes"
 
 #: extension.js:760
 msgid "Caffeine enabled"
-msgstr "Caffeine est activé"
+msgstr "Caféine est activé"
 
 #: extension.js:762
 msgid "Night Light paused"
@@ -45,7 +45,7 @@ msgstr "Mode nuit suspendu"
 
 #: extension.js:767
 msgid "Caffeine disabled"
-msgstr "Caffeine est désactivé"
+msgstr "Caféine est désactivé"
 
 #: extension.js:769
 msgid "Night Light resumed"
@@ -73,11 +73,11 @@ msgstr "Mode de déclenchement"
 
 #: preferences/appsPage.js:58
 msgid "Apps trigger Caffeine mode"
-msgstr "Mode de déclenchement applicatif de Caffeine"
+msgstr "Mode de déclenchement applicatif de Caféine"
 
 #: preferences/appsPage.js:59
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Spécifier la façon dont les applications vont déclencher Caffeine"
+msgstr "Spécifier la façon dont les applications vont déclencher Caféine"
 
 #: preferences/appsPage.js:73
 msgid "Add"
@@ -85,7 +85,7 @@ msgstr "Ajouter"
 
 #: preferences/appsPage.js:77
 msgid "Apps that trigger Caffeine"
-msgstr "Applications qui déclenchent Caffeine"
+msgstr "Applications qui déclenchent Caféine"
 
 #: preferences/displayPage.js:32 preferences/displayPage.js:42
 msgid "Display"
@@ -105,11 +105,11 @@ msgstr "Jamais"
 
 #: preferences/displayPage.js:51
 msgid "Show status indicator in top panel"
-msgstr "Afficher l’indicateur Caffeine dans la barre supérieure"
+msgstr "Afficher l’indicateur Caféine dans la barre supérieure"
 
 #: preferences/displayPage.js:52
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Activer ou désactiver l’icône de Caffeine dans la barre supérieure"
+msgstr "Activer ou désactiver l’icône de Caféine dans la barre supérieure"
 
 #: preferences/displayPage.js:63
 msgid "Show timer in top panel"
@@ -125,7 +125,7 @@ msgstr "Notifications"
 
 #: preferences/displayPage.js:76
 msgid "Enable notifications when Caffeine is enabled or disabled"
-msgstr "Activer les notifications quand Caffeine est activé ou désactivé"
+msgstr "Activer les notifications quand Caféine est activé ou désactivé"
 
 #: preferences/displayPage.js:98
 msgid "Status indicator position"

--- a/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2022-10-07 16:40+0200\n"
 "Last-Translator: Pakaoraki <pakaoraki@gmx.com>\n"
 "Language-Team: French\n"
@@ -23,35 +23,35 @@ msgstr ""
 "X-Generator: Poedit 3.1.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "Caféine"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "Caféine minuteur"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr "Infini"
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr " minutes"
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr "Caféine est activé"
 
-#: extension.js:768
+#: extension.js:766
 msgid "Night Light paused"
 msgstr "Mode nuit suspendu"
 
-#: extension.js:773
+#: extension.js:771
 msgid "Caffeine disabled"
 msgstr "Caféine est désactivé"
 
-#: extension.js:775
+#: extension.js:773
 msgid "Night Light resumed"
 msgstr "Mode nuit réactivé"
 

--- a/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/fr/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,14 +2,15 @@
 # This file is distributed under the same license as the Caffeine extension.
 # Jean-Philippe Braun <eon@patapon.info>, 2014.
 # Simon Elst <kirmaha@duck.com>, 2022.
+# Pakaoraki <pakaoraki@gmx.com>, 2023.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:01+0100\n"
 "PO-Revision-Date: 2022-10-07 16:40+0200\n"
-"Last-Translator: Simon Elst <kirmaha@duck.com>\n"
+"Last-Translator: Pakaoraki <pakaoraki@gmx.com>\n"
 "Language-Team: French\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -23,7 +24,6 @@ msgstr ""
 "X-Poedit-SearchPath-0: ../../..\n"
 
 #: extension.js:101
-#, fuzzy
 msgid "Caffeine timer"
 msgstr "Caffeine minuteur"
 
@@ -33,38 +33,35 @@ msgstr "Infini"
 
 #: extension.js:218 extension.js:793 preferences/generalPage.js:217
 msgid " minutes"
-msgstr ""
+msgstr " minutes"
 
 #: extension.js:760
 msgid "Caffeine enabled"
-msgstr "Caféine est activé"
+msgstr "Caffeine est activé"
 
 #: extension.js:762
-#, fuzzy
 msgid "Night Light paused"
 msgstr "Mode nuit suspendu"
 
 #: extension.js:767
-#, fuzzy
 msgid "Caffeine disabled"
-msgstr "Caféine est activé"
+msgstr "Caffeine est désactivé"
 
 #: extension.js:769
-#, fuzzy
 msgid "Night Light resumed"
 msgstr "Mode nuit réactivé"
 
 #: preferences/appsPage.js:29
 msgid "Running"
-msgstr ""
+msgstr "En cours d'exécution"
 
 #: preferences/appsPage.js:30
 msgid "Focus"
-msgstr ""
+msgstr "Focalisé"
 
 #: preferences/appsPage.js:31
 msgid "Active workspace"
-msgstr ""
+msgstr "Bureau actif"
 
 #: preferences/appsPage.js:38
 msgid "Apps"
@@ -72,17 +69,15 @@ msgstr "Applications"
 
 #: preferences/appsPage.js:49
 msgid "Trigger mode"
-msgstr ""
+msgstr "Mode de déclenchement"
 
 #: preferences/appsPage.js:58
-#, fuzzy
 msgid "Apps trigger Caffeine mode"
-msgstr "Applications qui déclenchent Caféine"
+msgstr "Mode de déclenchement applicatif de Caffeine"
 
 #: preferences/appsPage.js:59
-#, fuzzy
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Applications qui déclenchent Caféine"
+msgstr "Spécifier la façon dont les applications vont déclencher Caffeine"
 
 #: preferences/appsPage.js:73
 msgid "Add"
@@ -90,7 +85,7 @@ msgstr "Ajouter"
 
 #: preferences/appsPage.js:77
 msgid "Apps that trigger Caffeine"
-msgstr "Applications qui déclenchent Caféine"
+msgstr "Applications qui déclenchent Caffeine"
 
 #: preferences/displayPage.js:32 preferences/displayPage.js:42
 msgid "Display"
@@ -114,15 +109,13 @@ msgstr "Afficher l’indicateur Caffeine dans la barre supérieure"
 
 #: preferences/displayPage.js:52
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Activer ou désactiver l’icône de Caféine dans la barre supérieure"
+msgstr "Activer ou désactiver l’icône de Caffeine dans la barre supérieure"
 
 #: preferences/displayPage.js:63
-#, fuzzy
 msgid "Show timer in top panel"
 msgstr "Afficher le minuteur dans la barre supérieure"
 
 #: preferences/displayPage.js:64
-#, fuzzy
 msgid "Enable or disable the timer in the top panel"
 msgstr "Activer ou désactiver l'affichage du minuteur dans la barre supérieure"
 
@@ -132,10 +125,9 @@ msgstr "Notifications"
 
 #: preferences/displayPage.js:76
 msgid "Enable notifications when Caffeine is enabled or disabled"
-msgstr "Activer les notifications quand Caféine est activé ou désactivé"
+msgstr "Activer les notifications quand Caffeine est activé ou désactivé"
 
 #: preferences/displayPage.js:98
-#, fuzzy
 msgid "Status indicator position"
 msgstr "Position de l'icone"
 
@@ -161,8 +153,7 @@ msgstr "Activer pour les applications en plein écran"
 
 #: preferences/generalPage.js:67
 msgid "Automatically enable when an app enters fullscreen mode"
-msgstr ""
-"Activer automatiquement lorsqu’une application entre en mode plein écran"
+msgstr "Activer automatiquement lorsqu’une application entre en mode plein écran"
 
 #: preferences/generalPage.js:78
 msgid "Remember state"
@@ -170,9 +161,7 @@ msgstr "Se souvenir de l’état"
 
 #: preferences/generalPage.js:79
 msgid "Remember the last state across sessions and reboots"
-msgstr ""
-"Se souvenir du dernier état au-delà des changements de session et "
-"redémarrages"
+msgstr "Se souvenir du dernier état au-delà des changements de session et redémarrages"
 
 #: preferences/generalPage.js:90
 msgid "Pause and resume Night Light"
@@ -188,9 +177,8 @@ msgid "Allow screen blank"
 msgstr "Autoriser la mise en veille de l'écran seulement"
 
 #: preferences/generalPage.js:103
-#, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "Activer les notifications quand Caféine est activé ou désactivé"
+msgstr "Autoriser la mise en veille de l'écran quand Caféine est activé"
 
 #: preferences/generalPage.js:118
 msgid "Timer"
@@ -201,7 +189,6 @@ msgid "Durations"
 msgstr "Durées"
 
 #: preferences/generalPage.js:167
-#, fuzzy
 msgid "Shortcut"
 msgstr "Raccourci"
 
@@ -234,9 +221,8 @@ msgstr ""
 "(nom de fichier desktop)"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
-#, fuzzy
 msgid "Store caffeine toggle state"
-msgstr "Enregistrer l’état utilisateur de Caféine"
+msgstr "Enregistrer l’état de Caféine"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
@@ -249,7 +235,6 @@ msgstr "Durée du minuteur (en minutes)"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:42
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:43
-#, fuzzy
 msgid "Specify index of duration range for the timer"
 msgstr "Index de selection des durées du minuteur"
 
@@ -278,7 +263,6 @@ msgid "Show timer"
 msgstr "Afficher le minuteur"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:63
-#, fuzzy
 msgid "Show timer when enabled/disabled"
 msgstr "Afficher le minuteur si activé/désactivé"
 
@@ -293,16 +277,13 @@ msgstr "Contrôle du Mode nuit"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
-msgstr ""
-"Définir la manière dont Caféine interagit avec les réglages du Mode nuit."
+msgstr "Définir la manière dont Caféine interagit avec les réglages du Mode nuit."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
-#, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled."
 msgstr "Activer les notifications quand Caféine est activé ou désactivé"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
-#, fuzzy
 msgid "Trigger App control mode"
 msgstr "Contrôle du Mode nuit"
 

--- a/caffeine@patapon.info/locale/hu/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/hu/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2018-06-22 21:22+0200\n"
 "Last-Translator: Kardos László <lacesz@NOSPAM@ox dot io>\n"
 "Language-Team: \n"
@@ -13,30 +13,34 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 
 #: extension.js:101
-msgid "Caffeine timer"
-msgstr ""
+msgid "Caffeine"
+msgstr "Koffein"
 
-#: extension.js:216
+#: extension.js:102
+msgid "Caffeine timer"
+msgstr "Koffein timer"
+
+#: extension.js:217
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:762
+#: extension.js:768
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:767
+#: extension.js:773
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:769
+#: extension.js:775
 msgid "Night Light resumed"
 msgstr ""
 
@@ -107,7 +111,7 @@ msgstr "Indikátor megjelenítése a panelen"
 #: preferences/displayPage.js:63
 #, fuzzy
 msgid "Show timer in top panel"
-msgstr "Caffeine mutatása a felső panelen"
+msgstr "Koffein mutatása a felső panelen"
 
 #: preferences/displayPage.js:64
 #, fuzzy
@@ -227,11 +231,11 @@ msgstr ""
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 #, fuzzy
 msgid "Store caffeine toggle state"
-msgstr "Caffeine felhasználói állapot tárolása"
+msgstr "Koffein felhasználói állapot tárolása"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
-msgstr "Caffeine felhasználói állapot tárolása"
+msgstr "Koffein felhasználói állapot tárolása"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
@@ -245,7 +249,7 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Caffeine állapot visszaállítása"
+msgstr "Koffein állapot visszaállítása"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"

--- a/caffeine@patapon.info/locale/hu/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/hu/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2018-06-22 21:22+0200\n"
 "Last-Translator: Kardos László <lacesz@NOSPAM@ox dot io>\n"
 "Language-Team: \n"
@@ -12,35 +12,35 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "Koffein"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "Koffein timer"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:768
+#: extension.js:766
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:773
+#: extension.js:771
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:775
+#: extension.js:773
 msgid "Night Light resumed"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/it_IT/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/it_IT/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2023-01-13 14:43+0200\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Giuseppe Pignataro (Fastbyte01) <rogepix@gmail.com>\n"
@@ -18,30 +18,34 @@ msgstr ""
 "X-Poedit-SearchPath-0: ../../..\n"
 
 #: extension.js:101
-msgid "Caffeine timer"
-msgstr ""
+msgid "Caffeine"
+msgstr "Caffeina"
 
-#: extension.js:216
+#: extension.js:102
+msgid "Caffeine timer"
+msgstr "Caffeina timer"
+
+#: extension.js:217
 msgid "Infinite"
 msgstr "Infinito"
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr " minuti"
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
-msgstr "Caffeine abilitata"
+msgstr "Caffeina abilitata"
 
-#: extension.js:762
+#: extension.js:768
 msgid "Night Light paused"
 msgstr "Luce notturna in pausa"
 
-#: extension.js:767
+#: extension.js:773
 msgid "Caffeine disabled"
-msgstr "Caffeine disabilitato"
+msgstr "Caffeina disabilitato"
 
-#: extension.js:769
+#: extension.js:775
 msgid "Night Light resumed"
 msgstr "Luce notturna ripristinata"
 
@@ -67,11 +71,11 @@ msgstr "Modalità di attivazione"
 
 #: preferences/appsPage.js:58
 msgid "Apps trigger Caffeine mode"
-msgstr "Le app che attivano la modalità Caffeine"
+msgstr "Le app che attivano la modalità Caffeina"
 
 #: preferences/appsPage.js:59
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Scegli il modo in cui le app attiveranno Caffeine"
+msgstr "Scegli il modo in cui le app attiveranno Caffeina"
 
 #: preferences/appsPage.js:73
 msgid "Add"
@@ -79,7 +83,7 @@ msgstr "Aggiungi"
 
 #: preferences/appsPage.js:77
 msgid "Apps that trigger Caffeine"
-msgstr "Applicazioni che abilitano caffeine"
+msgstr "Applicazioni che abilitano Caffeina"
 
 #: preferences/displayPage.js:32 preferences/displayPage.js:42
 msgid "Display"
@@ -103,7 +107,7 @@ msgstr "Mostra l'indicatore di stato nel pannello superiore"
 
 #: preferences/displayPage.js:52
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Abilita o disabilita l'icona Caffeine nel pannello superiore"
+msgstr "Abilita o disabilita l'icona Caffeina nel pannello superiore"
 
 #: preferences/displayPage.js:63
 msgid "Show timer in top panel"
@@ -119,7 +123,7 @@ msgstr "Notifiche"
 
 #: preferences/displayPage.js:76
 msgid "Enable notifications when Caffeine is enabled or disabled"
-msgstr "Abilita le notifiche quando Caffeine è abilitata o disabilitata"
+msgstr "Abilita le notifiche quando Caffeina è abilitata o disabilitata"
 
 #: preferences/displayPage.js:98
 msgid "Status indicator position"
@@ -127,7 +131,8 @@ msgstr "Posizione indicatore di stato"
 
 #: preferences/displayPage.js:99
 msgid "The position relative of indicator icon to other items"
-msgstr "La posizione relativa dell'icona dell'indicatore rispetto ad altri elementi"
+msgstr ""
+"La posizione relativa dell'icona dell'indicatore rispetto ad altri elementi"
 
 #: preferences/generalPage.js:32
 msgid "For apps on list"
@@ -163,7 +168,7 @@ msgstr "Mostra notifiche quando abilitato/disabilitato"
 
 #: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
-msgstr "Attiva la modalità notturna insieme allo stato di Caffeine"
+msgstr "Attiva la modalità notturna insieme allo stato di Caffeina"
 
 #: preferences/generalPage.js:102
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
@@ -172,7 +177,7 @@ msgstr "Consenti schermo vuoto"
 
 #: preferences/generalPage.js:103
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "Consenti lo spegnimento dello schermo quando la Caffeine è abilitata"
+msgstr "Consenti lo spegnimento dello schermo quando la Caffeina è abilitata"
 
 #: preferences/generalPage.js:118
 msgid "Timer"
@@ -216,11 +221,11 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 msgid "Store caffeine toggle state"
-msgstr "Memorizza lo stato di attivazione/disattivazione di Caffeine"
+msgstr "Memorizza lo stato di attivazione/disattivazione di Caffeina"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
-msgstr "Salva lo stato di caffeine dell'utente"
+msgstr "Salva lo stato di Caffeina dell'utente"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
@@ -234,7 +239,7 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Ripristina lo stato di caffeine"
+msgstr "Ripristina lo stato di Caffeina"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -272,12 +277,12 @@ msgstr "Modalità di controllo della modalità notturna"
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
-"Imposta il modo in cui caffeine interagisce con l'impostazione della "
+"Imposta il modo in cui Caffeina interagisce con l'impostazione della "
 "Modalità notturna."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
-msgstr "Consenti lo spegnimento dello schermo quando Caffeine è abilitata."
+msgstr "Consenti lo spegnimento dello schermo quando Caffeina è abilitata."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
@@ -289,7 +294,7 @@ msgstr "Imposta il metodo di attivazione per le app."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
-msgstr "Scorciatoia per attivare/disattivare Caffeine."
+msgstr "Scorciatoia per attivare/disattivare Caffeina."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
@@ -301,15 +306,16 @@ msgstr "Altezza predefinita per la finestra delle preferenze"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:100
 msgid "Visible position offset of status icon in indicator menu"
-msgstr "Offset della posizione visibile dell'icona di stato nel menu dell'indicatore"
+msgstr ""
+"Offset della posizione visibile dell'icona di stato nel menu dell'indicatore"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
-"Offset della posizione reale dell'icona di stato nel menu degli indicatori che ne include "
-"uno invisibile"
+"Offset della posizione reale dell'icona di stato nel menu degli indicatori "
+"che ne include uno invisibile"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"
@@ -322,10 +328,13 @@ msgstr "Indice dell'ultima voce nel menu degli indicatori"
 #~ msgstr "Sospensione automatica e salvaschermo abilitati"
 
 #~ msgid "Auto suspend and screensaver disabled. Night Light paused."
-#~ msgstr "Sospensione automatica e salvaschermo disattivati. Luce notturna in pausa."
+#~ msgstr ""
+#~ "Sospensione automatica e salvaschermo disattivati. Luce notturna in pausa."
 
 #~ msgid "Auto suspend and screensaver enabled. Night Light resumed."
-#~ msgstr "Sospensione automatica e salvaschermo abilitati. La luce notturna è ripristinata."
+#~ msgstr ""
+#~ "Sospensione automatica e salvaschermo abilitati. La luce notturna è "
+#~ "ripristinata."
 
 #~ msgid "DEPRECATED. Pause/resume Night Light"
 #~ msgstr "DEPRECATO. Metti in pausa/riprendi la luce notturna"
@@ -335,7 +344,9 @@ msgstr "Indice dell'ultima voce nel menu degli indicatori"
 
 #~ msgid ""
 #~ "Pause/resume Night Light for defined application when enabled/disabled"
-#~ msgstr "Metti in pausa/riprendi la luce notturna per l'applicazione definita quando abilitata/disabilitata"
+#~ msgstr ""
+#~ "Metti in pausa/riprendi la luce notturna per l'applicazione definita "
+#~ "quando abilitata/disabilitata"
 
 #~ msgid "Add Application"
 #~ msgstr "Aggiungi applicazione"
@@ -344,7 +355,7 @@ msgstr "Indice dell'ultima voce nel menu degli indicatori"
 #~ msgstr "Abilita notifiche"
 
 #~ msgid "Applications which enable Caffeine automatically"
-#~ msgstr "Applicazioni che abilitano Caffeine automaticamente"
+#~ msgstr "Applicazioni che abilitano Caffeina automaticamente"
 
 #~ msgid "Create new matching rule"
 #~ msgstr "Crea una nuova regola corrispondente"

--- a/caffeine@patapon.info/locale/it_IT/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/it_IT/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2023-01-13 14:43+0200\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Giuseppe Pignataro (Fastbyte01) <rogepix@gmail.com>\n"
@@ -17,35 +17,35 @@ msgstr ""
 "X-Generator: Poedit 2.0.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "Caffeina"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "Caffeina timer"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr "Infinito"
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr " minuti"
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr "Caffeina abilitata"
 
-#: extension.js:768
+#: extension.js:766
 msgid "Night Light paused"
 msgstr "Luce notturna in pausa"
 
-#: extension.js:773
+#: extension.js:771
 msgid "Caffeine disabled"
 msgstr "Caffeina disabilitato"
 
-#: extension.js:775
+#: extension.js:773
 msgid "Night Light resumed"
 msgstr "Luce notturna ripristinata"
 

--- a/caffeine@patapon.info/locale/ja/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/ja/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2017-05-05 22:28+0900\n"
 "Last-Translator: Jean-Philippe Braun <eon@patapon.info>\n"
 "Language-Team: French\n"
@@ -18,31 +18,35 @@ msgstr ""
 "X-Poedit-SearchPath-0: ../../..\n"
 
 #: extension.js:101
-msgid "Caffeine timer"
-msgstr ""
+msgid "Caffeine"
+msgstr "カフェイン"
 
-#: extension.js:216
+#: extension.js:102
+msgid "Caffeine timer"
+msgstr "カフェイン timer"
+
+#: extension.js:217
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
 msgstr "Caféine est activé"
 
-#: extension.js:762
+#: extension.js:768
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:767
+#: extension.js:773
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caféine est activé"
 
-#: extension.js:769
+#: extension.js:775
 msgid "Night Light resumed"
 msgstr ""
 
@@ -101,22 +105,22 @@ msgstr "一度もない"
 #: preferences/displayPage.js:51
 #, fuzzy
 msgid "Show status indicator in top panel"
-msgstr "Caffeine をトップバーに表示する"
+msgstr "カフェイン をトップバーに表示する"
 
 #: preferences/displayPage.js:52
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Caffeine をトップバーに表示する"
+msgstr "カフェイン をトップバーに表示する"
 
 #: preferences/displayPage.js:63
 #, fuzzy
 msgid "Show timer in top panel"
-msgstr "Caffeine をトップバーに表示する"
+msgstr "カフェイン をトップバーに表示する"
 
 #: preferences/displayPage.js:64
 #, fuzzy
 msgid "Enable or disable the timer in the top panel"
-msgstr "Caffeine をトップバーに表示する"
+msgstr "カフェイン をトップバーに表示する"
 
 #: preferences/displayPage.js:75
 #, fuzzy
@@ -130,7 +134,7 @@ msgstr ""
 #: preferences/displayPage.js:98
 #, fuzzy
 msgid "Status indicator position"
-msgstr "Caffeine をトップバーに表示する"
+msgstr "カフェイン をトップバーに表示する"
 
 #: preferences/displayPage.js:99
 msgid "The position relative of indicator icon to other items"
@@ -249,7 +253,7 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
-msgstr "Caffeine をトップバーに表示する"
+msgstr "カフェイン をトップバーに表示する"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
@@ -340,7 +344,7 @@ msgstr ""
 #~ msgstr "通知を有効にする"
 
 #~ msgid "Applications which enable Caffeine automatically"
-#~ msgstr "Caffeine を自動的に有効にするアプリケーション"
+#~ msgstr "カフェイン を自動的に有効にするアプリケーション"
 
 #~ msgid "Create new matching rule"
 #~ msgstr "新規ルール"

--- a/caffeine@patapon.info/locale/ja/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/ja/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2017-05-05 22:28+0900\n"
 "Last-Translator: Jean-Philippe Braun <eon@patapon.info>\n"
 "Language-Team: French\n"
@@ -17,36 +17,36 @@ msgstr ""
 "X-Generator: Poedit 2.0.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "カフェイン"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "カフェイン timer"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr "Caféine est activé"
 
-#: extension.js:768
+#: extension.js:766
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:773
+#: extension.js:771
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caféine est activé"
 
-#: extension.js:775
+#: extension.js:773
 msgid "Night Light resumed"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/ko/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/ko/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2022-09-10 10:53+0900\n"
 "Last-Translator: kuroehanako <kmj10727@gmail.com>\n"
 "Language-Team: \n"
@@ -16,31 +16,35 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 
 #: extension.js:101
-msgid "Caffeine timer"
-msgstr ""
+msgid "Caffeine"
+msgstr "카페인"
 
-#: extension.js:216
+#: extension.js:102
+msgid "Caffeine timer"
+msgstr "카페인 timer"
+
+#: extension.js:217
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:762
+#: extension.js:768
 #, fuzzy
 msgid "Night Light paused"
 msgstr "야간 모드를 멈춥니"
 
-#: extension.js:767
+#: extension.js:773
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:769
+#: extension.js:775
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "야간 모드를 다시 켭니"

--- a/caffeine@patapon.info/locale/ko/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/ko/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2022-09-10 10:53+0900\n"
 "Last-Translator: kuroehanako <kmj10727@gmail.com>\n"
 "Language-Team: \n"
@@ -15,36 +15,36 @@ msgstr ""
 "X-Poedit-Basepath: ../../gnome-shell-extension-caffeine-master\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "카페인"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "카페인 timer"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:768
+#: extension.js:766
 #, fuzzy
 msgid "Night Light paused"
 msgstr "야간 모드를 멈춥니"
 
-#: extension.js:773
+#: extension.js:771
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:775
+#: extension.js:773
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "야간 모드를 다시 켭니"

--- a/caffeine@patapon.info/locale/nl/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/nl/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2023-02-07 14:23+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch\n"
@@ -18,30 +18,34 @@ msgstr ""
 "X-Poedit-SearchPath-0: ../../..\n"
 
 #: extension.js:101
-msgid "Caffeine timer"
-msgstr "Caffeine-tijdklok"
+msgid "Caffeine"
+msgstr "Cafeïne"
 
-#: extension.js:216
+#: extension.js:102
+msgid "Caffeine timer"
+msgstr "Cafeïne-tijdklok"
+
+#: extension.js:217
 msgid "Infinite"
 msgstr "Onbeperkt"
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
-msgstr "Caffeine is ingeschakeld"
+msgstr "Cafeïne is ingeschakeld"
 
-#: extension.js:762
+#: extension.js:768
 msgid "Night Light paused"
 msgstr "Nachtlicht is onderbroken"
 
-#: extension.js:767
+#: extension.js:773
 msgid "Caffeine disabled"
-msgstr "Caffeine is uitgeschakeld"
+msgstr "Cafeïne is uitgeschakeld"
 
-#: extension.js:769
+#: extension.js:775
 msgid "Night Light resumed"
 msgstr "Nachtlicht is hervat"
 
@@ -67,11 +71,11 @@ msgstr "In-/Uitschakelmodus"
 
 #: preferences/appsPage.js:58
 msgid "Apps trigger Caffeine mode"
-msgstr "Toepassingen die Caffeine in-/uitschakelen"
+msgstr "Toepassingen die Cafeïne in-/uitschakelen"
 
 #: preferences/appsPage.js:59
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Geef aan hoe toepassingen Caffeine in-/uitschakelen"
+msgstr "Geef aan hoe toepassingen Cafeïne in-/uitschakelen"
 
 #: preferences/appsPage.js:73
 msgid "Add"
@@ -79,7 +83,7 @@ msgstr "Toevoegen"
 
 #: preferences/appsPage.js:77
 msgid "Apps that trigger Caffeine"
-msgstr "Toepassingen die Caffeine in-/uitschakelen"
+msgstr "Toepassingen die Cafeïne in-/uitschakelen"
 
 #: preferences/displayPage.js:32 preferences/displayPage.js:42
 msgid "Display"
@@ -103,7 +107,7 @@ msgstr "Indicator tonen op bovenbalk"
 
 #: preferences/displayPage.js:52
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Toon of verberg het Caffeine-pictogram op de bovenbalk"
+msgstr "Toon of verberg het Cafeïne-pictogram op de bovenbalk"
 
 #: preferences/displayPage.js:63
 msgid "Show timer in top panel"
@@ -119,7 +123,7 @@ msgstr "Meldingen"
 
 #: preferences/displayPage.js:76
 msgid "Enable notifications when Caffeine is enabled or disabled"
-msgstr "Toon meldingen als Caffeine wordt in- of uitgeschakeld"
+msgstr "Toon meldingen als Cafeïne wordt in- of uitgeschakeld"
 
 #: preferences/displayPage.js:98
 #, fuzzy
@@ -165,7 +169,7 @@ msgstr "Nachtlicht onderbreken en hervatten"
 
 #: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
-msgstr "Schakel nachtlicht tegelijk met Caffeine in/uit"
+msgstr "Schakel nachtlicht tegelijk met Cafeïne in/uit"
 
 #: preferences/generalPage.js:102
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
@@ -174,7 +178,7 @@ msgstr "Scherm uitschakelen"
 
 #: preferences/generalPage.js:103
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "Schakel het scherm uit als Caffeine wordt ingeschakeld"
+msgstr "Schakel het scherm uit als Cafeïne wordt ingeschakeld"
 
 #: preferences/generalPage.js:118
 msgid "Timer"
@@ -253,7 +257,7 @@ msgstr "Meldingen tonen"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
-msgstr "Toon meldingen als Caffeine wordt in- of uitgeschakeld"
+msgstr "Toon meldingen als Cafeïne wordt in- of uitgeschakeld"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
@@ -274,7 +278,7 @@ msgstr "Nachtlichtbediening"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
-msgstr "Geef aan hoe Caffeine dient om te gaan met de nachtlichtinstelling."
+msgstr "Geef aan hoe Cafeïne dient om te gaan met de nachtlichtinstelling."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
@@ -290,7 +294,7 @@ msgstr "Stel de aan-/uitmethode van toepassingen in."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
-msgstr "Sneltoets om Caffeine aan/uit te zetten."
+msgstr "Sneltoets om Cafeïne aan/uit te zetten."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
@@ -341,7 +345,7 @@ msgstr "Vorige itemlocatie in indicatormenu"
 #~ msgstr "VEROUDERD // Nachtlicht onderbreken/hervatten"
 
 #~ msgid "Pause/resume Night Light when enabled/disabled"
-#~ msgstr "Onderbreek/Hervat nachtlicht bij in-/uitschakelen van Caffeine"
+#~ msgstr "Onderbreek/Hervat nachtlicht bij in-/uitschakelen van Cafeïne"
 
 #~ msgid "DEPRECATED. Pause/resume Night Light for defined applications only"
 #~ msgstr ""
@@ -351,7 +355,7 @@ msgstr "Vorige itemlocatie in indicatormenu"
 #~ "Pause/resume Night Light for defined application when enabled/disabled"
 #~ msgstr ""
 #~ "Onderbreek/Hervat nachtlicht bij een opgegeven toepassing bij in-/"
-#~ "uitschakelen van Caffeine"
+#~ "uitschakelen van Cafeïne"
 
 #~ msgid "Add Application"
 #~ msgstr "Toepassing toevoegen"
@@ -360,7 +364,7 @@ msgstr "Vorige itemlocatie in indicatormenu"
 #~ msgstr "Benachrichtigungen aktivieren"
 
 #~ msgid "Applications which enable Caffeine automatically"
-#~ msgstr "Anwendungen, welche Caffeine automatisch aktivieren"
+#~ msgstr "Anwendungen, welche Cafeïne automatisch aktivieren"
 
 #~ msgid "Create new matching rule"
 #~ msgstr "Neue Regel definieren"

--- a/caffeine@patapon.info/locale/nl/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/nl/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2023-02-07 14:23+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch\n"
@@ -17,35 +17,35 @@ msgstr ""
 "X-Generator: Poedit 3.2.2\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "Cafeïne"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "Cafeïne-tijdklok"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr "Onbeperkt"
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr "Cafeïne is ingeschakeld"
 
-#: extension.js:768
+#: extension.js:766
 msgid "Night Light paused"
 msgstr "Nachtlicht is onderbroken"
 
-#: extension.js:773
+#: extension.js:771
 msgid "Caffeine disabled"
 msgstr "Cafeïne is uitgeschakeld"
 
-#: extension.js:775
+#: extension.js:773
 msgid "Night Light resumed"
 msgstr "Nachtlicht is hervat"
 

--- a/caffeine@patapon.info/locale/pl/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/pl/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2016-10-02 17:24+0100\n"
 "Last-Translator: Piotr Wittchen <piotr@wittchen.biz.pl>\n"
 "Language-Team: Polish\n"
@@ -17,36 +17,36 @@ msgstr ""
 "X-Generator: Vim\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "Kofeina"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "Kofeina timer"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr "Kofeina włączone"
 
-#: extension.js:768
+#: extension.js:766
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:773
+#: extension.js:771
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Kofeina włączone"
 
-#: extension.js:775
+#: extension.js:773
 msgid "Night Light resumed"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/pl/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/pl/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2016-10-02 17:24+0100\n"
 "Last-Translator: Piotr Wittchen <piotr@wittchen.biz.pl>\n"
 "Language-Team: Polish\n"
@@ -18,31 +18,35 @@ msgstr ""
 "X-Poedit-SearchPath-0: ../../..\n"
 
 #: extension.js:101
-msgid "Caffeine timer"
-msgstr ""
+msgid "Caffeine"
+msgstr "Kofeina"
 
-#: extension.js:216
+#: extension.js:102
+msgid "Caffeine timer"
+msgstr "Kofeina timer"
+
+#: extension.js:217
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
-msgstr "Caffeine włączone"
+msgstr "Kofeina włączone"
 
-#: extension.js:762
+#: extension.js:768
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:767
+#: extension.js:773
 #, fuzzy
 msgid "Caffeine disabled"
-msgstr "Caffeine włączone"
+msgstr "Kofeina włączone"
 
-#: extension.js:769
+#: extension.js:775
 msgid "Night Light resumed"
 msgstr ""
 
@@ -101,22 +105,22 @@ msgstr "Nigdy"
 #: preferences/displayPage.js:51
 #, fuzzy
 msgid "Show status indicator in top panel"
-msgstr "Pokazuj Caffeine w górnym panelu"
+msgstr "Pokazuj Kofeina w górnym panelu"
 
 #: preferences/displayPage.js:52
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Pokazuj Caffeine w górnym panelu"
+msgstr "Pokazuj Kofeina w górnym panelu"
 
 #: preferences/displayPage.js:63
 #, fuzzy
 msgid "Show timer in top panel"
-msgstr "Pokazuj Caffeine w górnym panelu"
+msgstr "Pokazuj Kofeina w górnym panelu"
 
 #: preferences/displayPage.js:64
 #, fuzzy
 msgid "Enable or disable the timer in the top panel"
-msgstr "Pokazuj Caffeine w górnym panelu"
+msgstr "Pokazuj Kofeina w górnym panelu"
 
 #: preferences/displayPage.js:75
 #, fuzzy
@@ -130,7 +134,7 @@ msgstr ""
 #: preferences/displayPage.js:98
 #, fuzzy
 msgid "Status indicator position"
-msgstr "Pokazuj Caffeine w górnym panelu"
+msgstr "Pokazuj Kofeina w górnym panelu"
 
 #: preferences/displayPage.js:99
 msgid "The position relative of indicator icon to other items"
@@ -250,7 +254,7 @@ msgstr ""
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 #, fuzzy
 msgid "Show the indicator on the top panel"
-msgstr "Pokazuj Caffeine w górnym panelu"
+msgstr "Pokazuj Kofeina w górnym panelu"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 #, fuzzy
@@ -342,7 +346,7 @@ msgstr ""
 #~ msgstr "Włącz notyfikacje"
 
 #~ msgid "Applications which enable Caffeine automatically"
-#~ msgstr "Aplikacje, które aktywują Caffeine automatycznie"
+#~ msgstr "Aplikacje, które aktywują Kofeina automatycznie"
 
 #~ msgid "Create new matching rule"
 #~ msgstr "Stwórz nową regułę dopasowania"

--- a/caffeine@patapon.info/locale/pt_BR/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/pt_BR/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2020-02-25 20:16-0300\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
 "Language-Team: Brazilian Portuguese <gnome-pt_br-list@gnome.org>\n"
@@ -23,31 +23,35 @@ msgstr ""
 "X-Poedit-SearchPath-0: ../../..\n"
 
 #: extension.js:101
-msgid "Caffeine timer"
-msgstr "Temporizador do Caffeine"
+msgid "Caffeine"
+msgstr "Cafeína"
 
-#: extension.js:216
+#: extension.js:102
+msgid "Caffeine timer"
+msgstr "Temporizador do Cafeína"
+
+#: extension.js:217
 msgid "Infinite"
 msgstr "Infinito"
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
-msgstr "Caffeine ativado"
+msgstr "Cafeína ativado"
 
-#: extension.js:762
+#: extension.js:768
 msgid "Night Light paused"
 msgstr "Luz Noturna pausado"
 
-#: extension.js:767
+#: extension.js:773
 #, fuzzy
 msgid "Caffeine disabled"
-msgstr "Caffeine desativado"
+msgstr "Cafeína desativado"
 
-#: extension.js:769
+#: extension.js:775
 msgid "Night Light resumed"
 msgstr "Luz Noturna resumido"
 
@@ -73,11 +77,11 @@ msgstr "Modo de Gatilho"
 
 #: preferences/appsPage.js:58
 msgid "Apps trigger Caffeine mode"
-msgstr "Aplicativos que ativam o modo Caffeine"
+msgstr "Aplicativos que ativam o modo Cafeína"
 
 #: preferences/appsPage.js:59
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Escolha a maneira que os aplicativos irão ativar o Caffeine"
+msgstr "Escolha a maneira que os aplicativos irão ativar o Cafeína"
 
 #: preferences/appsPage.js:73
 msgid "Add"
@@ -85,7 +89,7 @@ msgstr "Adicionar"
 
 #: preferences/appsPage.js:77
 msgid "Apps that trigger Caffeine"
-msgstr "Aplicativos que ativam o modo Caffeine"
+msgstr "Aplicativos que ativam o modo Cafeína"
 
 #: preferences/displayPage.js:32 preferences/displayPage.js:42
 msgid "Display"
@@ -116,7 +120,7 @@ msgstr "Mostrar o indicador no painel superior"
 #: preferences/displayPage.js:63
 #, fuzzy
 msgid "Show timer in top panel"
-msgstr "Mostrar Caffeine no painel superior"
+msgstr "Mostrar Cafeína no painel superior"
 
 #: preferences/displayPage.js:64
 #, fuzzy
@@ -179,7 +183,7 @@ msgstr "Mostra notificações quando ativado/desativado"
 
 #: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
-msgstr "Alternar Luz Noturna junto do estado do Caffeine"
+msgstr "Alternar Luz Noturna junto do estado do Cafeína"
 
 #: preferences/generalPage.js:102
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
@@ -189,7 +193,7 @@ msgstr "Permitir tela desligada"
 #: preferences/generalPage.js:103
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "Permitir desligar a tela quando o Caffeine está ativado"
+msgstr "Permitir desligar a tela quando o Cafeína está ativado"
 
 #: preferences/generalPage.js:118
 msgid "Timer"
@@ -234,11 +238,11 @@ msgstr ""
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 #, fuzzy
 msgid "Store caffeine toggle state"
-msgstr "Armazenar estado do caffeine do usuário"
+msgstr "Armazenar estado do Cafeína do usuário"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
-msgstr "Armazenar estado do caffeine do usuário"
+msgstr "Armazenar estado do Cafeína do usuário"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
@@ -253,7 +257,7 @@ msgstr "Especifique o tempo do temporizador em minutos"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Restaurar estado do caffeine"
+msgstr "Restaurar estado do Cafeína"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -292,7 +296,7 @@ msgstr "Modo de controle da Luz Noturna"
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
-"Configure a maneira que o Caffeine interage com a configuração da Luz Noturna"
+"Configure a maneira que o Cafeína interage com a configuração da Luz Noturna"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 #, fuzzy
@@ -309,7 +313,7 @@ msgstr "Configure o metodo de gatilho para aplicativos"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
-msgstr "Atalho para alterar o Caffeine"
+msgstr "Atalho para alterar o Cafeína"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
@@ -371,7 +375,7 @@ msgstr "Último índice do icone do menu indicador"
 #~ msgstr "Ativar as notificações"
 
 #~ msgid "Applications which enable Caffeine automatically"
-#~ msgstr "Aplicativos que ativam o Caffeine automaticamente"
+#~ msgstr "Aplicativos que ativam o Cafeína automaticamente"
 
 #~ msgid "Create new matching rule"
 #~ msgstr "Criar nova regra"

--- a/caffeine@patapon.info/locale/pt_BR/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/pt_BR/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2020-02-25 20:16-0300\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
 "Language-Team: Brazilian Portuguese <gnome-pt_br-list@gnome.org>\n"
@@ -22,36 +22,36 @@ msgstr ""
 "X-Generator: Gtranslator 3.32.0\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "Cafeína"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "Temporizador do Cafeína"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr "Infinito"
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr "Cafeína ativado"
 
-#: extension.js:768
+#: extension.js:766
 msgid "Night Light paused"
 msgstr "Luz Noturna pausado"
 
-#: extension.js:773
+#: extension.js:771
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Cafeína desativado"
 
-#: extension.js:775
+#: extension.js:773
 msgid "Night Light resumed"
 msgstr "Luz Noturna resumido"
 

--- a/caffeine@patapon.info/locale/pt_PT/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/pt_PT/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2016-12-02 10:01+0100\n"
 "Last-Translator: Steeven Lopes <steevenlopes@outlook.com>\n"
 "Language-Team: Portuguese\n"
@@ -17,36 +17,36 @@ msgstr ""
 "X-Generator: Poedit 1.6.10\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "Cafeína"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "Cafeína timer"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr "Cafeína ativado"
 
-#: extension.js:768
+#: extension.js:766
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:773
+#: extension.js:771
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Cafeína ativado"
 
-#: extension.js:775
+#: extension.js:773
 msgid "Night Light resumed"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/pt_PT/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/pt_PT/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2016-12-02 10:01+0100\n"
 "Last-Translator: Steeven Lopes <steevenlopes@outlook.com>\n"
 "Language-Team: Portuguese\n"
@@ -18,31 +18,35 @@ msgstr ""
 "X-Poedit-SearchPath-0: ../../..\n"
 
 #: extension.js:101
-msgid "Caffeine timer"
-msgstr ""
+msgid "Caffeine"
+msgstr "Cafeína"
 
-#: extension.js:216
+#: extension.js:102
+msgid "Caffeine timer"
+msgstr "Cafeína timer"
+
+#: extension.js:217
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
-msgstr "Caffeine ativado"
+msgstr "Cafeína ativado"
 
-#: extension.js:762
+#: extension.js:768
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:767
+#: extension.js:773
 #, fuzzy
 msgid "Caffeine disabled"
-msgstr "Caffeine ativado"
+msgstr "Cafeína ativado"
 
-#: extension.js:769
+#: extension.js:775
 msgid "Night Light resumed"
 msgstr ""
 
@@ -101,22 +105,22 @@ msgstr "Nunca"
 #: preferences/displayPage.js:51
 #, fuzzy
 msgid "Show status indicator in top panel"
-msgstr "Mostrar Caffeine no painel superior"
+msgstr "Mostrar Cafeína no painel superior"
 
 #: preferences/displayPage.js:52
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Mostrar Caffeine no painel superior"
+msgstr "Mostrar Cafeína no painel superior"
 
 #: preferences/displayPage.js:63
 #, fuzzy
 msgid "Show timer in top panel"
-msgstr "Mostrar Caffeine no painel superior"
+msgstr "Mostrar Cafeína no painel superior"
 
 #: preferences/displayPage.js:64
 #, fuzzy
 msgid "Enable or disable the timer in the top panel"
-msgstr "Mostrar Caffeine no painel superior"
+msgstr "Mostrar Cafeína no painel superior"
 
 #: preferences/displayPage.js:75
 #, fuzzy
@@ -130,7 +134,7 @@ msgstr ""
 #: preferences/displayPage.js:98
 #, fuzzy
 msgid "Status indicator position"
-msgstr "Mostrar Caffeine no painel superior"
+msgstr "Mostrar Cafeína no painel superior"
 
 #: preferences/displayPage.js:99
 msgid "The position relative of indicator icon to other items"
@@ -342,7 +346,7 @@ msgstr ""
 #~ msgstr "Ativar notificações"
 
 #~ msgid "Applications which enable Caffeine automatically"
-#~ msgstr "Aplicações que automaticamente ativam o Caffeine"
+#~ msgstr "Aplicações que automaticamente ativam o Cafeína"
 
 #~ msgid "Create new matching rule"
 #~ msgstr "Criar uma nova regra"

--- a/caffeine@patapon.info/locale/ru/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/ru/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2022-02-08 13:07+0300\n"
 "Last-Translator: Aleksandr Melman <Alexmelman88@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -18,31 +18,35 @@ msgstr ""
 "X-Poedit-SearchPath-0: ../../..\n"
 
 #: extension.js:101
-msgid "Caffeine timer"
-msgstr ""
+msgid "Caffeine"
+msgstr "Kофеин"
 
-#: extension.js:216
+#: extension.js:102
+msgid "Caffeine timer"
+msgstr "Kофеин timer"
+
+#: extension.js:217
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:762
+#: extension.js:768
 #, fuzzy
 msgid "Night Light paused"
 msgstr "Ночная подсветка"
 
-#: extension.js:767
+#: extension.js:773
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:769
+#: extension.js:775
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "Ночная подсветка"

--- a/caffeine@patapon.info/locale/ru/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/ru/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2022-02-08 13:07+0300\n"
 "Last-Translator: Aleksandr Melman <Alexmelman88@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -17,36 +17,36 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "Kофеин"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "Kофеин timer"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:768
+#: extension.js:766
 #, fuzzy
 msgid "Night Light paused"
 msgstr "Ночная подсветка"
 
-#: extension.js:773
+#: extension.js:771
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:775
+#: extension.js:773
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "Ночная подсветка"

--- a/caffeine@patapon.info/locale/sk/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/sk/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2015-01-16 10:24+0100\n"
 "Last-Translator: Dušan Kazik <prescott66@gmail.com>\n"
 "Language-Team: Slovak\n"
@@ -17,36 +17,36 @@ msgstr ""
 "X-Generator: Poedit 1.7.3\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "Kofeín"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "Kofeín timer"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr "Kofeín aktiviert"
 
-#: extension.js:768
+#: extension.js:766
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:773
+#: extension.js:771
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Kofeín aktiviert"
 
-#: extension.js:775
+#: extension.js:773
 msgid "Night Light resumed"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/sk/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/sk/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2015-01-16 10:24+0100\n"
 "Last-Translator: Dušan Kazik <prescott66@gmail.com>\n"
 "Language-Team: Slovak\n"
@@ -18,31 +18,35 @@ msgstr ""
 "X-Poedit-SearchPath-0: ../../..\n"
 
 #: extension.js:101
-msgid "Caffeine timer"
-msgstr ""
+msgid "Caffeine"
+msgstr "Kofeín"
 
-#: extension.js:216
+#: extension.js:102
+msgid "Caffeine timer"
+msgstr "Kofeín timer"
+
+#: extension.js:217
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
-msgstr "Caffeine aktiviert"
+msgstr "Kofeín aktiviert"
 
-#: extension.js:762
+#: extension.js:768
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:767
+#: extension.js:773
 #, fuzzy
 msgid "Caffeine disabled"
-msgstr "Caffeine aktiviert"
+msgstr "Kofeín aktiviert"
 
-#: extension.js:769
+#: extension.js:775
 msgid "Night Light resumed"
 msgstr ""
 
@@ -101,22 +105,22 @@ msgstr "Nikdy"
 #: preferences/displayPage.js:51
 #, fuzzy
 msgid "Show status indicator in top panel"
-msgstr "Zobraziť Caffeine v hornej lište"
+msgstr "Zobraziť Kofeín v hornej lište"
 
 #: preferences/displayPage.js:52
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Zobraziť Caffeine v hornej lište"
+msgstr "Zobraziť Kofeín v hornej lište"
 
 #: preferences/displayPage.js:63
 #, fuzzy
 msgid "Show timer in top panel"
-msgstr "Zobraziť Caffeine v hornej lište"
+msgstr "Zobraziť Kofeín v hornej lište"
 
 #: preferences/displayPage.js:64
 #, fuzzy
 msgid "Enable or disable the timer in the top panel"
-msgstr "Zobraziť Caffeine v hornej lište"
+msgstr "Zobraziť Kofeín v hornej lište"
 
 #: preferences/displayPage.js:75
 #, fuzzy
@@ -130,7 +134,7 @@ msgstr ""
 #: preferences/displayPage.js:98
 #, fuzzy
 msgid "Status indicator position"
-msgstr "Zobraziť Caffeine v hornej lište"
+msgstr "Zobraziť Kofeín v hornej lište"
 
 #: preferences/displayPage.js:99
 msgid "The position relative of indicator icon to other items"
@@ -250,7 +254,7 @@ msgstr ""
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 #, fuzzy
 msgid "Show the indicator on the top panel"
-msgstr "Zobraziť Caffeine v hornej lište"
+msgstr "Zobraziť Kofeín v hornej lište"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 #, fuzzy
@@ -342,7 +346,7 @@ msgstr ""
 #~ msgstr "Povoliť oznámenia"
 
 #~ msgid "Applications which enable Caffeine automatically"
-#~ msgstr "Aplikácie, ktoré automaticky povolia Caffeine"
+#~ msgstr "Aplikácie, ktoré automaticky povolia Kofeín"
 
 #~ msgid "Create new matching rule"
 #~ msgstr "Vytvorenie nového pravidla"

--- a/caffeine@patapon.info/locale/sv/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/sv/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2018-04-04 20:35+0200\n"
 "Last-Translator: Morgan Antonsson <morgan.antonsson@gmail.com>\n"
 "Language-Team: \n"
@@ -12,30 +12,34 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: extension.js:101
-msgid "Caffeine timer"
-msgstr ""
+msgid "Caffeine"
+msgstr "Koffein"
 
-#: extension.js:216
+#: extension.js:102
+msgid "Caffeine timer"
+msgstr "Koffein timer"
+
+#: extension.js:217
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:762
+#: extension.js:768
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:767
+#: extension.js:773
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:769
+#: extension.js:775
 msgid "Night Light resumed"
 msgstr ""
 
@@ -104,7 +108,7 @@ msgstr "Visa indikator i panelen"
 #: preferences/displayPage.js:63
 #, fuzzy
 msgid "Show timer in top panel"
-msgstr "Visa Caffeine i panelen"
+msgstr "Visa Koffein i panelen"
 
 #: preferences/displayPage.js:64
 #, fuzzy
@@ -220,11 +224,11 @@ msgstr "En lista av strängar med program-ID:n (skrivbordets filnamn)"
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 #, fuzzy
 msgid "Store caffeine toggle state"
-msgstr "Spara caffeines användarstatus"
+msgstr "Spara Koffein användarstatus"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
-msgstr "Spara caffeines användarstatus"
+msgstr "Spara Koffein användarstatus"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
@@ -238,7 +242,7 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Återställ caffeine-status"
+msgstr "Återställ Koffein-status"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -352,7 +356,7 @@ msgstr ""
 #~ msgstr "Aktivera notifieringar"
 
 #~ msgid "Applications which enable Caffeine automatically"
-#~ msgstr "Program som automatiskt aktiverar Caffeine"
+#~ msgstr "Program som automatiskt aktiverar Koffein"
 
 #~ msgid "Create new matching rule"
 #~ msgstr "Skapa ny matchande regel"

--- a/caffeine@patapon.info/locale/sv/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/sv/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2018-04-04 20:35+0200\n"
 "Last-Translator: Morgan Antonsson <morgan.antonsson@gmail.com>\n"
 "Language-Team: \n"
@@ -11,35 +11,35 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "Koffein"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "Koffein timer"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:768
+#: extension.js:766
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:773
+#: extension.js:771
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:775
+#: extension.js:773
 msgid "Night Light resumed"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/tr/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/tr/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2019-03-21 06:48+0300\n"
 "Last-Translator: Serdar Sağlam <teknomobil@yandex.com>\n"
 "Language-Team: Turkish <gnome-turk@gnome.org>\n"
@@ -19,31 +19,35 @@ msgstr ""
 "X-Generator: Gtranslator 3.32.0\n"
 
 #: extension.js:101
-msgid "Caffeine timer"
-msgstr ""
+msgid "Caffeine"
+msgstr "Kafein"
 
-#: extension.js:216
+#: extension.js:102
+msgid "Caffeine timer"
+msgstr "Kafein timer"
+
+#: extension.js:217
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
-msgstr "Caffeine aktif"
+msgstr "Kafein aktif"
 
-#: extension.js:762
+#: extension.js:768
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:767
+#: extension.js:773
 #, fuzzy
 msgid "Caffeine disabled"
-msgstr "Caffeine aktif"
+msgstr "Kafein aktif"
 
-#: extension.js:769
+#: extension.js:775
 msgid "Night Light resumed"
 msgstr ""
 
@@ -112,7 +116,7 @@ msgstr "Göstergeyi üst panelde göster"
 #: preferences/displayPage.js:63
 #, fuzzy
 msgid "Show timer in top panel"
-msgstr "Caffeine üst panelde görünsün"
+msgstr "Kafein üst panelde görünsün"
 
 #: preferences/displayPage.js:64
 #, fuzzy

--- a/caffeine@patapon.info/locale/tr/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/tr/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2019-03-21 06:48+0300\n"
 "Last-Translator: Serdar Sağlam <teknomobil@yandex.com>\n"
 "Language-Team: Turkish <gnome-turk@gnome.org>\n"
@@ -18,36 +18,36 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Generator: Gtranslator 3.32.0\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "Kafein"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "Kafein timer"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr ""
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr "Kafein aktif"
 
-#: extension.js:768
+#: extension.js:766
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:773
+#: extension.js:771
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Kafein aktif"
 
-#: extension.js:775
+#: extension.js:773
 msgid "Night Light resumed"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/zh_CN/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/zh_CN/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 12:33+0100\n"
+"POT-Creation-Date: 2023-04-19 22:28+0200\n"
 "PO-Revision-Date: 2022-06-30 11:54-0400\n"
 "Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <debian-l10n-chinese@lists.debian.org>\n"
@@ -18,30 +18,34 @@ msgstr ""
 "X-Poedit-SearchPath-0: ../../..\n"
 
 #: extension.js:101
-msgid "Caffeine timer"
-msgstr "Caffeine 定时器"
+msgid "Caffeine"
+msgstr "咖啡因"
 
-#: extension.js:216
+#: extension.js:102
+msgid "Caffeine timer"
+msgstr "咖啡因 定时器"
+
+#: extension.js:217
 msgid "Infinite"
 msgstr "持续"
 
-#: extension.js:218 extension.js:793 preferences/generalPage.js:217
+#: extension.js:219 extension.js:799 preferences/generalPage.js:217
 msgid " minutes"
 msgstr " 分钟"
 
-#: extension.js:760
+#: extension.js:766
 msgid "Caffeine enabled"
-msgstr "Caffeine 已开启"
+msgstr "咖啡因 已开启"
 
-#: extension.js:762
+#: extension.js:768
 msgid "Night Light paused"
 msgstr "夜灯已暂停"
 
-#: extension.js:767
+#: extension.js:773
 msgid "Caffeine disabled"
-msgstr "Caffeine 已关闭"
+msgstr "咖啡因 已关闭"
 
-#: extension.js:769
+#: extension.js:775
 msgid "Night Light resumed"
 msgstr "夜灯已恢复"
 
@@ -67,11 +71,11 @@ msgstr "触发模式"
 
 #: preferences/appsPage.js:58
 msgid "Apps trigger Caffeine mode"
-msgstr "触发 Caffeine 的应用"
+msgstr "触发 咖啡因 的应用"
 
 #: preferences/appsPage.js:59
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "触发 Caffeine 的应用"
+msgstr "触发 咖啡因 的应用"
 
 #: preferences/appsPage.js:73
 msgid "Add"
@@ -79,7 +83,7 @@ msgstr "添加"
 
 #: preferences/appsPage.js:77
 msgid "Apps that trigger Caffeine"
-msgstr "触发 Caffeine 的应用"
+msgstr "触发 咖啡因 的应用"
 
 #: preferences/displayPage.js:32 preferences/displayPage.js:42
 msgid "Display"
@@ -103,15 +107,15 @@ msgstr "在顶部面板显示状态指示器"
 
 #: preferences/displayPage.js:52
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "在顶部面板启用或禁用 Caffeine 图标"
+msgstr "在顶部面板启用或禁用 咖啡因 图标"
 
 #: preferences/displayPage.js:63
 msgid "Show timer in top panel"
-msgstr "在顶部面板显示 Caffeine 计时器"
+msgstr "在顶部面板显示 咖啡因 计时器"
 
 #: preferences/displayPage.js:64
 msgid "Enable or disable the timer in the top panel"
-msgstr "在顶部面板启用或禁用 Caffeine 计时器"
+msgstr "在顶部面板启用或禁用 咖啡因 计时器"
 
 #: preferences/displayPage.js:75
 msgid "Notifications"
@@ -119,7 +123,7 @@ msgstr "通知"
 
 #: preferences/displayPage.js:76
 msgid "Enable notifications when Caffeine is enabled or disabled"
-msgstr "在 Caffeine 被启用或禁用时显示通知"
+msgstr "在 咖啡因 被启用或禁用时显示通知"
 
 #: preferences/displayPage.js:98
 msgid "Status indicator position"
@@ -163,7 +167,7 @@ msgstr "暂停和恢复夜灯"
 
 #: preferences/generalPage.js:91
 msgid "Toggles the night light together with Caffeine's state"
-msgstr "随 Caffeine 的状态切换夜灯"
+msgstr "随 咖啡因 的状态切换夜灯"
 
 #: preferences/generalPage.js:102
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
@@ -172,7 +176,7 @@ msgstr "允许屏幕保护"
 
 #: preferences/generalPage.js:103
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "允许在 Caffeine 启用时关闭屏幕"
+msgstr "允许在 咖啡因 启用时关闭屏幕"
 
 #: preferences/generalPage.js:118
 msgid "Timer"
@@ -214,11 +218,11 @@ msgstr "一个字符串的列表，每个字符串包含一个应用程序 id（
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 msgid "Store caffeine toggle state"
-msgstr "保存 caffeine 状态"
+msgstr "保存 咖啡因 状态"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
-msgstr "保存 caffeine 状态"
+msgstr "保存 咖啡因 状态"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
@@ -232,7 +236,7 @@ msgstr "指定计时器的持续时间"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "恢复 caffeine 状态"
+msgstr "恢复 咖啡因 状态"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -269,11 +273,11 @@ msgstr "夜灯控制模式"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
-msgstr "设置 Caffeine 和夜灯设置交互的方式。"
+msgstr "设置 咖啡因 和夜灯设置交互的方式。"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
-msgstr "允许在 Caffeine 启用时关闭屏幕"
+msgstr "允许在 咖啡因 启用时关闭屏幕"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
@@ -285,7 +289,7 @@ msgstr "设置应用的触发方式."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
-msgstr "切换 Caffeine 的快捷键"
+msgstr "切换 咖啡因 的快捷键"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"
@@ -344,7 +348,7 @@ msgstr "菜单中的最后一项"
 #~ msgstr "启用通知"
 
 #~ msgid "Applications which enable Caffeine automatically"
-#~ msgstr "自动激活 Caffeine 的程序"
+#~ msgstr "自动激活 咖啡因 的程序"
 
 #~ msgid "Create new matching rule"
 #~ msgstr "创建新的匹配规则"

--- a/caffeine@patapon.info/locale/zh_CN/LC_MESSAGES/gnome-shell-extension-caffeine.po
+++ b/caffeine@patapon.info/locale/zh_CN/LC_MESSAGES/gnome-shell-extension-caffeine.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-19 22:28+0200\n"
+"POT-Creation-Date: 2023-04-19 23:31+0200\n"
 "PO-Revision-Date: 2022-06-30 11:54-0400\n"
 "Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <debian-l10n-chinese@lists.debian.org>\n"
@@ -17,35 +17,35 @@ msgstr ""
 "X-Generator: Poedit 3.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:101
+#: extension.js:160
 msgid "Caffeine"
 msgstr "咖啡因"
 
-#: extension.js:102
+#: extension.js:177 extension.js:617
 msgid "Caffeine timer"
 msgstr "咖啡因 定时器"
 
-#: extension.js:217
+#: extension.js:215
 msgid "Infinite"
 msgstr "持续"
 
-#: extension.js:219 extension.js:799 preferences/generalPage.js:217
+#: extension.js:217 extension.js:797 preferences/generalPage.js:217
 msgid " minutes"
 msgstr " 分钟"
 
-#: extension.js:766
+#: extension.js:764
 msgid "Caffeine enabled"
 msgstr "咖啡因 已开启"
 
-#: extension.js:768
+#: extension.js:766
 msgid "Night Light paused"
 msgstr "夜灯已暂停"
 
-#: extension.js:773
+#: extension.js:771
 msgid "Caffeine disabled"
 msgstr "咖啡因 已关闭"
 
-#: extension.js:775
+#: extension.js:773
 msgid "Night Light resumed"
 msgstr "夜灯已恢复"
 


### PR DESCRIPTION
I noticed that in Lineageos they translated the menu 'Caffeine', so I thought it could make sens to make this change. 

Also, someone in #246 had this idea:

> I wonder if i should translate word "Caffeine"?

Let me know if it's something you'd like to see.