### PR TITLE
Fix Caffeine get stuck with app

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -785,7 +785,9 @@ class Caffeine extends QuickSettings.SystemIndicator {
             let appId = id !== null ? id : listAppId.next().value;
             if (appId !== undefined) {
                 let appInfo = Gio.DesktopAppInfo.new(appId);        
-                this._caffeineToggle.subtitle = appInfo.get_display_name();
+                this._caffeineToggle.subtitle = appId !== null 
+                    ? appInfo.get_display_name()
+                    : null;
             }
         }
     }

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -785,7 +785,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
             let appId = id !== null ? id : listAppId.next().value;
             if (appId !== undefined) {
                 let appInfo = Gio.DesktopAppInfo.new(appId);        
-                this._caffeineToggle.subtitle = appId !== null 
+                this._caffeineToggle.subtitle = appInfo !== null 
                     ? appInfo.get_display_name()
                     : null;
             }


### PR DESCRIPTION
I experienced a caffeine freeze with apps mode: when closing the app, the extension did not remove the inhibitor. I got this error:

```
JS ERROR: Exception in callback for signal: InhibitorRemoved: TypeError: appInfo is null
_updateAppSubtitle@/home/pak/.local/share/gnome-shell/extensions/caffeine@patapon.info/extension.js:788:17
_inhibitorRemoved@/home/pak/.local/share/gnome-shell/extensions/caffeine@patapon.info/extension.js:697:26
_callHandlers@resource:///org/gnome/gjs/modules/core/_signals.js:130:42
_emit@resource:///org/gnome/gjs/modules/core/_signals.js:119:10
_convertToNativeSignal@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:152:19
```

A test was missing on `appInfo`, this change will avoid this situation.