### PR TITLE
Corrected 'Caffeine timer' to 'Caffeine Timer'

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -98,7 +98,7 @@ const DBusSessionManagerInhibitorIface = '<node>\
 const DBusSessionManagerInhibitorProxy = Gio.DBusProxy.makeProxyWrapper(DBusSessionManagerInhibitorIface);
 
 const IndicatorName = 'Caffeine';
-const TimerMenuName = _('Caffeine timer');
+const TimerMenuName = _('Caffeine Timer');
 const DisabledIcon = 'my-caffeine-off-symbolic';
 const EnabledIcon = 'my-caffeine-on-symbolic';
 const TimerMenuIcon = 'stopwatch-symbolic';


### PR DESCRIPTION
This makes the capitals consistent with other shell menus

I've intentionally not updated the translation files with this PR, as it seems to get confused and comes up with some very incorrect translations, marking these as fuzzy. They're simple enough for their respective translators to fix, so I've left this for the next time those languages get updated translations.