### PR TITLE
Translate 'Caffeine' in all languages

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -157,7 +157,7 @@ class CaffeineToggle extends QuickSettings.QuickMenuToggle {
             // The 'label' property was renamed to 'title' in GNOME 44 but quick settings have otherwise
             // not been changed. The below line allows support for both GNOME 43 and 44+ by using the
             // appropriate property name based on the GNOME version.
-            [ShellVersion >= 44 ? 'title' : 'label']: IndicatorName,
+            [ShellVersion >= 44 ? 'title' : 'label']: _('Caffeine'),
             toggleMode: true
         });
 

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -97,7 +97,6 @@ const DBusSessionManagerInhibitorIface = '<node>\
 
 const DBusSessionManagerInhibitorProxy = Gio.DBusProxy.makeProxyWrapper(DBusSessionManagerInhibitorIface);
 
-const IndicatorName = 'Caffeine';
 const DisabledIcon = 'my-caffeine-off-symbolic';
 const EnabledIcon = 'my-caffeine-on-symbolic';
 const TimerMenuIcon = 'stopwatch-symbolic';
@@ -482,7 +481,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
 
     addInhibit(appId) {
         this._sessionManager.InhibitRemote(appId,
-            0, 'Inhibit by %s'.format(IndicatorName), this.inhibitFlags,
+            0, 'Inhibit by %s'.format(Me.metadata.name), this.inhibitFlags,
             (cookie) => {
                 this._inhibitionAddedFifo.push(appId);
                 // Init app data

--- a/caffeine@patapon.info/locale/ca.po
+++ b/caffeine@patapon.info/locale/ca.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2023-08-05 16:21+0200\n"
 "Last-Translator: Ícar N. S. <icar.nin@protonmail.com>\n"
 "Language-Team: Catalan\n"
@@ -18,67 +18,72 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:177 extension.js:622
+#: extension.js:159
+#, fuzzy
+msgid "Caffeine"
+msgstr "Temporitzador"
+
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr "Temporitzador"
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr "Infinit"
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr " minuts"
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr "Cafeïna activada"
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr "Llum nocturna pausada"
 
-#: extension.js:778
+#: extension.js:788
 msgid "Caffeine disabled"
 msgstr "Cafeïna desactivada"
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr "Llum nocturna reactivada"
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr "Aplicacions"
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr "Mode d'activació"
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr "S'està executant"
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr "Focus"
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr "Espai de treball actiu"
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 msgid "Apps trigger Caffeine mode"
 msgstr "Quan les aplicacions activen el mode cafeïna"
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 msgid "Choose the way apps will trigger Caffeine"
 msgstr "Escolliu amb quina condició les aplicacions activaran el mode cafeïna"
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "Afegiu"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
 msgstr "Aplicacions que activen el mode cafeïna"
 
@@ -90,11 +95,13 @@ msgstr "Pantalla"
 msgid "Only when active"
 msgstr "Només en actiu"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "Sempre"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "Mai"
 
@@ -131,77 +138,77 @@ msgid "The position relative of indicator icon to other items"
 msgstr ""
 "La posició de la icona indicadora de l'estat en relació als altres elements"
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr "Per les aplicacions a la llista"
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr "General"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr "Comportament"
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 msgid "Enable for fullscreen apps"
 msgstr "Activa per aplicacions en pantalla completa"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "Activa automàticament quan una aplicació canvia a pantalla completa"
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr "Recorda l'estat"
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 msgid "Remember the last state across sessions and reboots"
 msgstr "Recorda l'últim estat entre inicis de sessió i reinicis"
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr "Per les aplicacions a la llista"
+
+#: preferences/generalPage.js:85
 msgid "Pause and resume Night Light"
 msgstr "Pausa i activa la llum nocturna"
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Commuta la llum nocturna juntament amb el mode cafeïna"
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "Permet que la pantalla s'apagui"
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Permet que la pantalla s'apagui quan el mode cafeïna està activat"
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr "Temporitzador"
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr "Duracions"
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr "Drecera"
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr "Commuta la drecera"
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr "Usa la tecla retrocés per desvincular la drecera"
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr "Estableix a "
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr "Nova drecera..."
 
@@ -308,8 +315,8 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:104
 msgid ""
-"Real position offset of status icon in indicator menu that include "
-"invisible one"
+"Real position offset of status icon in indicator menu that include invisible "
+"one"
 msgstr ""
 "Posició real del desplaçament de la icona d'estat al menú d'indicadors que "
 "inclou un invisible"

--- a/caffeine@patapon.info/locale/ca.po
+++ b/caffeine@patapon.info/locale/ca.po
@@ -21,11 +21,11 @@ msgstr ""
 #: extension.js:159
 #, fuzzy
 msgid "Caffeine"
-msgstr "Temporitzador"
+msgstr "Cafeïna"
 
 #: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
-msgstr "Temporitzador"
+msgstr "Cafeïna Temporitzador"
 
 #: extension.js:214
 msgid "Infinite"

--- a/caffeine@patapon.info/locale/cs.po
+++ b/caffeine@patapon.info/locale/cs.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2023-04-12 18:40+0200\n"
 "Last-Translator: Kryštof Černý <cleerline1mc@gmail.com>\n"
 "Language-Team: Czech\n"
@@ -17,35 +17,35 @@ msgstr ""
 "X-Generator: Poedit 3.2.2\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "Kofein"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr "Časovač Kofein"
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr "Nekonečně"
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr " minut"
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr "Kofein povolen"
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr "Noční světlo pozastaveno"
 
-#: extension.js:778
+#: extension.js:788
 msgid "Caffeine disabled"
 msgstr "Kofein zakázán"
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr "Noční světlo obnoveno"
 
@@ -93,11 +93,13 @@ msgstr "Displej"
 msgid "Only when active"
 msgstr "Pouze když je aktivní"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "Vždy"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "Nikdy"
 
@@ -133,77 +135,77 @@ msgstr "Pozice indikátoru stavu"
 msgid "The position relative of indicator icon to other items"
 msgstr "Relativní pozice ikony k ostatním položkám"
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr "Pro aplikace na seznamu"
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr "Obecné"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr "Chování"
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 msgid "Enable for fullscreen apps"
 msgstr "Povolit pro celoobrazovkové aplikace"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "Automaticky povolit, když aplikace přejde do režimu celé obrazovky"
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr "Pamatovat stav"
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 msgid "Remember the last state across sessions and reboots"
 msgstr "Pamatovat si poslední stav mezi sezeními a restarty"
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr "Pro aplikace na seznamu"
+
+#: preferences/generalPage.js:85
 msgid "Pause and resume Night Light"
 msgstr "Pozastavit a obnovit Noční světlo"
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Přepne noční světlo spolu se stavem Kofein"
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "Povolit prázdnou obrazovku"
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Povolit vypínání obrazovky s povoleným Kofein"
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr "Časovač"
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr "Doby trvání"
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr "Zkratka"
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr "Zkratka přepnutí"
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr "Použijte backspace pro vymazání"
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr "Nastaveny na "
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr "Nová zkratka…"
 
@@ -273,8 +275,7 @@ msgstr "Režim řízení Nočního světla"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
-msgstr ""
-"Nastavte způsob, kterým Kofein interaguje s nastavením Nočního světla."
+msgstr "Nastavte způsob, kterým Kofein interaguje s nastavením Nočního světla."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."

--- a/caffeine@patapon.info/locale/cs.po
+++ b/caffeine@patapon.info/locale/cs.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2023-04-12 18:40+0200\n"
 "Last-Translator: Kryštof Černý <cleerline1mc@gmail.com>\n"
 "Language-Team: Czech\n"
@@ -17,10 +17,13 @@ msgstr ""
 "X-Generator: Poedit 3.2.2\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
+#: extension.js:160
+msgid "Caffeine"
+msgstr "Kofein"
+
 #: extension.js:177 extension.js:622
-#, fuzzy
 msgid "Caffeine Timer"
-msgstr "Časovač Caffeine"
+msgstr "Časovač Kofein"
 
 #: extension.js:215
 msgid "Infinite"
@@ -32,7 +35,7 @@ msgstr " minut"
 
 #: extension.js:771
 msgid "Caffeine enabled"
-msgstr "Caffeine povolen"
+msgstr "Kofein povolen"
 
 #: extension.js:773
 msgid "Night Light paused"
@@ -40,47 +43,47 @@ msgstr "Noční světlo pozastaveno"
 
 #: extension.js:778
 msgid "Caffeine disabled"
-msgstr "Caffeine zakázán"
+msgstr "Kofein zakázán"
 
 #: extension.js:780
 msgid "Night Light resumed"
 msgstr "Noční světlo obnoveno"
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr "Aplikace"
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr "Režim aktivování"
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr "Spuštěné"
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr "Jako současné okno"
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr "Na současné pracovní ploše"
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 msgid "Apps trigger Caffeine mode"
-msgstr "Aplikace spustí režim Caffeine, když jsou"
+msgstr "Aplikace spustí režim Kofein, když jsou"
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Vybrat způsob, jakým aplikace aktivují Caffeine"
+msgstr "Vybrat způsob, jakým aplikace aktivují Kofein"
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "Přidat"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
-msgstr "Aplikace, které aktivují Caffeine"
+msgstr "Aplikace, které aktivují Kofein"
 
 #: preferences/displayPage.js:33 preferences/displayPage.js:43
 msgid "Display"
@@ -104,7 +107,7 @@ msgstr "Zobrazit indikátor stavu v horní liště"
 
 #: preferences/displayPage.js:53
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Povolit nebo zakázat ikonu Caffeine v horní liště"
+msgstr "Povolit nebo zakázat ikonu Kofein v horní liště"
 
 #: preferences/displayPage.js:64
 msgid "Show timer in top panel"
@@ -120,7 +123,7 @@ msgstr "Upozornění"
 
 #: preferences/displayPage.js:77
 msgid "Enable notifications when Caffeine is enabled or disabled"
-msgstr "Povolit upozornění, když je Caffeine povoleno nebo zakázáno"
+msgstr "Povolit upozornění, když je Kofein povoleno nebo zakázáno"
 
 #: preferences/displayPage.js:99
 msgid "Status indicator position"
@@ -164,7 +167,7 @@ msgstr "Pozastavit a obnovit Noční světlo"
 
 #: preferences/generalPage.js:92
 msgid "Toggles the night light together with Caffeine's state"
-msgstr "Přepne noční světlo spolu se stavem Caffeine"
+msgstr "Přepne noční světlo spolu se stavem Kofein"
 
 #: preferences/generalPage.js:103
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
@@ -173,7 +176,7 @@ msgstr "Povolit prázdnou obrazovku"
 
 #: preferences/generalPage.js:104
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "Povolit vypínání obrazovky s povoleným Caffeine"
+msgstr "Povolit vypínání obrazovky s povoleným Kofein"
 
 #: preferences/generalPage.js:119
 msgid "Timer"
@@ -215,11 +218,11 @@ msgstr "Seznam řetězců, každý obsahující id aplikace (název desktop soub
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 msgid "Store caffeine toggle state"
-msgstr "Uložit stav zapnutí caffeine"
+msgstr "Uložit stav zapnutí Kofein"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
-msgstr "Uložit uživatelský stav caffeine"
+msgstr "Uložit uživatelský stav Kofein"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
@@ -233,7 +236,7 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Obnovit stav caffeine"
+msgstr "Obnovit stav Kofein"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -271,11 +274,11 @@ msgstr "Režim řízení Nočního světla"
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
-"Nastavte způsob, kterým Caffeine interaguje s nastavením Nočního světla."
+"Nastavte způsob, kterým Kofein interaguje s nastavením Nočního světla."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
-msgstr "Povolit vypínání obrazovky s povoleným Caffeine."
+msgstr "Povolit vypínání obrazovky s povoleným Kofein."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
@@ -287,7 +290,7 @@ msgstr "Nastavit režim spuštění pro aplikace."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
-msgstr "Zkratka pro přepnutí Caffeine."
+msgstr "Zkratka pro přepnutí Kofein."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"

--- a/caffeine@patapon.info/locale/de.po
+++ b/caffeine@patapon.info/locale/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2021-04-09 21:31-0400\n"
 "Last-Translator: WebSnke <websnke@tutanota.com>\n"
 "Language-Team: German\n"
@@ -17,10 +17,13 @@ msgstr ""
 "X-Generator: Poedit 2.4.2\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
+#: extension.js:160
+msgid "Caffeine"
+msgstr "Koffein"
+
 #: extension.js:177 extension.js:622
-#, fuzzy
 msgid "Caffeine Timer"
-msgstr "Caffeine-Timer"
+msgstr "Koffein-Timer"
 
 #: extension.js:215
 msgid "Infinite"
@@ -32,7 +35,7 @@ msgstr " Minuten"
 
 #: extension.js:771
 msgid "Caffeine enabled"
-msgstr "Caffeine aktiviert"
+msgstr "Koffein aktiviert"
 
 #: extension.js:773
 msgid "Night Light paused"
@@ -40,47 +43,47 @@ msgstr "Nachtmodus pausiert"
 
 #: extension.js:778
 msgid "Caffeine disabled"
-msgstr "Caffeine deaktiviert"
+msgstr "Koffein deaktiviert"
 
 #: extension.js:780
 msgid "Night Light resumed"
 msgstr "Nachtmodus fortgesetzt"
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr "Anwendungen"
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr ""
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr ""
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr "Fokus"
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr "Aktive Arbeitsfläche"
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 msgid "Apps trigger Caffeine mode"
-msgstr "Anwendungen, die Caffeine aktivieren"
+msgstr "Anwendungen, die Koffein aktivieren"
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Wähle, wie Anwendungen Caffeine aktivieren"
+msgstr "Wähle, wie Anwendungen Koffein aktivieren"
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
-msgstr "Anwendungen, die Caffeine aktivieren"
+msgstr "Anwendungen, die Koffein aktivieren"
 
 #: preferences/displayPage.js:33 preferences/displayPage.js:43
 msgid "Display"
@@ -104,15 +107,15 @@ msgstr "Indikator-Icon in der oberen Leiste anzeigen"
 
 #: preferences/displayPage.js:53
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Aktiviert oder deaktiviert das Caffeine Icon in der oberen Leiste"
+msgstr "Aktiviert oder deaktiviert das Koffein Icon in der oberen Leiste"
 
 #: preferences/displayPage.js:64
 msgid "Show timer in top panel"
-msgstr "Caffeine in der oberen Leiste anzeigen"
+msgstr "Koffein in der oberen Leiste anzeigen"
 
 #: preferences/displayPage.js:65
 msgid "Enable or disable the timer in the top panel"
-msgstr "Aktiviert oder deaktiviert das Caffeine Icon in der oberen Leiste"
+msgstr "Aktiviert oder deaktiviert das Koffein Icon in der oberen Leiste"
 
 #: preferences/displayPage.js:76
 msgid "Notifications"
@@ -164,7 +167,7 @@ msgstr "Nachtmodus unterbrechen"
 
 #: preferences/generalPage.js:92
 msgid "Toggles the night light together with Caffeine's state"
-msgstr "Unterbricht den Nachtmodus wenn Caffeine aktiviert wird"
+msgstr "Unterbricht den Nachtmodus wenn Koffein aktiviert wird"
 
 #: preferences/generalPage.js:103
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
@@ -173,7 +176,7 @@ msgstr "Erlaube es, den Bildschirm auszuschalten"
 
 #: preferences/generalPage.js:104
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "Ausschalten des Bildschirms, wenn Caffeine an ist, erlauben"
+msgstr "Ausschalten des Bildschirms, wenn Koffein an ist, erlauben"
 
 #: preferences/generalPage.js:119
 msgid "Timer"
@@ -236,7 +239,7 @@ msgstr "Index des Zeitraums für den Timer angeben"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Caffeines Zustand wiederherstellen"
+msgstr "Koffein Zustand wiederherstellen"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -244,7 +247,7 @@ msgstr "Indikator anzeigen"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
-msgstr "Caffeine-Indikator in der oberen Leiste anzeigen"
+msgstr "Koffein-Indikator in der oberen Leiste anzeigen"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
@@ -277,7 +280,7 @@ msgstr "Lege fest, wie Caffein mit dem Nachtmodus umgeht."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
-msgstr "Ausschalten des Bildschirms, wenn Caffeine an ist, erlauben"
+msgstr "Ausschalten des Bildschirms, wenn Koffein an ist, erlauben"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
@@ -289,7 +292,7 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
-msgstr "Tastenkombination um Caffeine zu öffnen."
+msgstr "Tastenkombination um Koffein zu öffnen."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"

--- a/caffeine@patapon.info/locale/de.po
+++ b/caffeine@patapon.info/locale/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2021-04-09 21:31-0400\n"
 "Last-Translator: WebSnke <websnke@tutanota.com>\n"
 "Language-Team: German\n"
@@ -17,35 +17,35 @@ msgstr ""
 "X-Generator: Poedit 2.4.2\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "Koffein"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr "Koffein-Timer"
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr "Unendlich"
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr " Minuten"
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr "Koffein aktiviert"
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr "Nachtmodus pausiert"
 
-#: extension.js:778
+#: extension.js:788
 msgid "Caffeine disabled"
 msgstr "Koffein deaktiviert"
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr "Nachtmodus fortgesetzt"
 
@@ -93,11 +93,13 @@ msgstr ""
 msgid "Only when active"
 msgstr "Nur wenn aktiv"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "Immer"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "Nie"
 
@@ -133,77 +135,77 @@ msgstr "Position der Statusanzeige"
 msgid "The position relative of indicator icon to other items"
 msgstr "Die Position des Indikatorsymbols relativ zu anderen Elementen"
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr "Für Apps auf Liste"
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr "Allgemein"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr "Verhalten"
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 msgid "Enable for fullscreen apps"
 msgstr "Aktiviere für Vollbild Anwendungen"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "Automatisch aktivieren wenn Anwendung in den Vollbildmodus wechselt"
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr "Zustand wiederherstellen"
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 msgid "Remember the last state across sessions and reboots"
 msgstr "Nach einem Neustart den Zustand wiederherstellen"
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr "Für Apps auf Liste"
+
+#: preferences/generalPage.js:85
 msgid "Pause and resume Night Light"
 msgstr "Nachtmodus unterbrechen"
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Unterbricht den Nachtmodus wenn Koffein aktiviert wird"
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "Erlaube es, den Bildschirm auszuschalten"
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Ausschalten des Bildschirms, wenn Koffein an ist, erlauben"
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr "Timer"
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr "Dauer"
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr "Tastenkombination"
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr "Nutze die Leertaste zum löschen"
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr "Einstellen auf"
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr "Neuer Beschleuniger…"
 

--- a/caffeine@patapon.info/locale/es.po
+++ b/caffeine@patapon.info/locale/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2015-11-28 21:06-0300\n"
 "Last-Translator: Sergio D. Márquez <marquez.sergio.d@gmail.com>\n"
 "Language-Team: Spanish\n"
@@ -17,10 +17,13 @@ msgstr ""
 "X-Generator: Poedit 1.8.6\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
+#: extension.js:160
+msgid "Caffeine"
+msgstr "Cafeína"
+
 #: extension.js:177 extension.js:622
-#, fuzzy
 msgid "Caffeine Timer"
-msgstr "Caffeine temporizador"
+msgstr "Cafeína temporizador"
 
 #: extension.js:215
 msgid "Infinite"
@@ -28,62 +31,61 @@ msgstr "Infinito"
 
 #: extension.js:217 extension.js:806 preferences/generalPage.js:218
 msgid " minutes"
-msgstr ""
+msgstr " minutos"
 
 #: extension.js:771
 msgid "Caffeine enabled"
-msgstr "Caffeine activado"
+msgstr "Cafeína activado"
 
 #: extension.js:773
 msgid "Night Light paused"
 msgstr ""
 
 #: extension.js:778
-#, fuzzy
 msgid "Caffeine disabled"
-msgstr "Caffeine activado"
+msgstr "Cafeína desactivado"
 
 #: extension.js:780
 msgid "Night Light resumed"
 msgstr ""
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr "Aplicaciones"
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr ""
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr ""
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr ""
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr ""
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 #, fuzzy
 msgid "Apps trigger Caffeine mode"
-msgstr "Aplicaciones que activan Caffeine"
+msgstr "Aplicaciones que activan Cafeína"
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 #, fuzzy
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Aplicaciones que activan Caffeine"
+msgstr "Aplicaciones que activan Cafeína"
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "Agregar"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
-msgstr "Aplicaciones que activan Caffeine"
+msgstr "Aplicaciones que activan Cafeína"
 
 #: preferences/displayPage.js:33 preferences/displayPage.js:43
 msgid "Display"
@@ -104,22 +106,22 @@ msgstr "Nunca"
 #: preferences/displayPage.js:52
 #, fuzzy
 msgid "Show status indicator in top panel"
-msgstr "Mostrar Caffeine en el panel superior"
+msgstr "Mostrar Cafeína en el panel superior"
 
 #: preferences/displayPage.js:53
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Mostrar Caffeine en el panel superior"
+msgstr "Mostrar Cafeína en el panel superior"
 
 #: preferences/displayPage.js:64
 #, fuzzy
 msgid "Show timer in top panel"
-msgstr "Mostrar Caffeine en el panel superior"
+msgstr "Mostrar Cafeína en el panel superior"
 
 #: preferences/displayPage.js:65
 #, fuzzy
 msgid "Enable or disable the timer in the top panel"
-msgstr "Mostrar Caffeine en el panel superior"
+msgstr "Mostrar Cafeína en el panel superior"
 
 #: preferences/displayPage.js:76
 #, fuzzy
@@ -134,7 +136,7 @@ msgstr "Mostrar notificaciones de habilitado/deshabilitado"
 #: preferences/displayPage.js:99
 #, fuzzy
 msgid "Status indicator position"
-msgstr "Mostrar Caffeine en el panel superior"
+msgstr "Mostrar Cafeína en el panel superior"
 
 #: preferences/displayPage.js:100
 msgid "The position relative of indicator icon to other items"
@@ -235,11 +237,11 @@ msgstr ""
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 #, fuzzy
 msgid "Store caffeine toggle state"
-msgstr "Guardar estado de usuario de Caffeine"
+msgstr "Guardar estado de usuario de Cafeína"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
-msgstr "Guardar estado de usuario de Caffeine"
+msgstr "Guardar estado de usuario de Cafeína"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
@@ -253,7 +255,7 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Restablecer estado de Caffeine"
+msgstr "Restablecer estado de Cafeína"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -262,7 +264,7 @@ msgstr "Mostrar indicador"
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 #, fuzzy
 msgid "Show the indicator on the top panel"
-msgstr "Mostrar Caffeine en el panel superior"
+msgstr "Mostrar Cafeína en el panel superior"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 #, fuzzy

--- a/caffeine@patapon.info/locale/es.po
+++ b/caffeine@patapon.info/locale/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2015-11-28 21:06-0300\n"
 "Last-Translator: Sergio D. Márquez <marquez.sergio.d@gmail.com>\n"
 "Language-Team: Spanish\n"
@@ -17,35 +17,35 @@ msgstr ""
 "X-Generator: Poedit 1.8.6\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "Cafeína"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr "Cafeína temporizador"
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr "Infinito"
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr " minutos"
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr "Cafeína activado"
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:778
+#: extension.js:788
 msgid "Caffeine disabled"
 msgstr "Cafeína desactivado"
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr ""
 
@@ -95,11 +95,13 @@ msgstr "monitor"
 msgid "Only when active"
 msgstr "Solo activa"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "Siempre"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "Nunca"
 
@@ -142,83 +144,83 @@ msgstr "Mostrar Cafeína en el panel superior"
 msgid "The position relative of indicator icon to other items"
 msgstr ""
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr "Para aplicaciones en la lista"
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr "Comportamiento"
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Activar cuando una aplicación a pantalla completa esté en ejecución"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 "Activar automáticamente cuando una aplicación entra en modo de pantalla "
 "completa"
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr "Recordar estado"
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "Restablecer estado despues de reiniciar"
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr "Para aplicaciones en la lista"
+
+#: preferences/generalPage.js:85
 #, fuzzy
 msgid "Pause and resume Night Light"
 msgstr "Mostrar notificaciones de habilitado/deshabilitado"
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Mostrar notificaciones de habilitado/deshabilitado"
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr ""
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr ""
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr "Atajo"
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr ""
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/fr.po
+++ b/caffeine@patapon.info/locale/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2022-10-07 16:40+0200\n"
 "Last-Translator: Pakaoraki <pakaoraki@gmx.com>\n"
 "Language-Team: French\n"
@@ -23,35 +23,35 @@ msgstr ""
 "X-Generator: Poedit 3.1.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "Caféine"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr "Caféine Minuteur"
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr "Infini"
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr " minutes"
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr "Caféine est activé"
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr "Mode nuit suspendu"
 
-#: extension.js:778
+#: extension.js:788
 msgid "Caffeine disabled"
 msgstr "Caféine est désactivé"
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr "Mode nuit réactivé"
 
@@ -99,11 +99,13 @@ msgstr "Affichage"
 msgid "Only when active"
 msgstr "Si activé"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "Toujours"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "Jamais"
 
@@ -139,80 +141,80 @@ msgstr "Position de l'icone"
 msgid "The position relative of indicator icon to other items"
 msgstr "La position de l'icone dans la barre supérieure"
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr "Pour les applications de la liste"
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr "Général"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr "Comportement"
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 msgid "Enable for fullscreen apps"
 msgstr "Activer pour les applications en plein écran"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 "Activer automatiquement lorsqu’une application entre en mode plein écran"
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr "Se souvenir de l’état"
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 msgid "Remember the last state across sessions and reboots"
 msgstr ""
 "Se souvenir du dernier état au-delà des changements de session et "
 "redémarrages"
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr "Pour les applications de la liste"
+
+#: preferences/generalPage.js:85
 msgid "Pause and resume Night Light"
 msgstr "Suspendre et réactiver le Mode nuit"
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Commute le Mode nuit en fonction de l’état de Caféine"
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "Autoriser la mise en veille de l'écran seulement"
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Autoriser la mise en veille de l'écran quand Caféine est activé"
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr "Minuteur"
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr "Durées"
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr "Raccourci"
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr "Raccourci clavier"
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr "Utiliser Retour arrière pour effacer"
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr "Réglé sur "
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr "Nouvel accélérateur…"
 

--- a/caffeine@patapon.info/locale/fr.po
+++ b/caffeine@patapon.info/locale/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2022-10-07 16:40+0200\n"
 "Last-Translator: Pakaoraki <pakaoraki@gmx.com>\n"
 "Language-Team: French\n"
@@ -23,9 +23,13 @@ msgstr ""
 "X-Generator: Poedit 3.1.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
+#: extension.js:160
+msgid "Caffeine"
+msgstr "Caféine"
+
 #: extension.js:177 extension.js:622
 msgid "Caffeine Timer"
-msgstr "Caffeine Minuteur"
+msgstr "Caféine Minuteur"
 
 #: extension.js:215
 msgid "Infinite"
@@ -37,7 +41,7 @@ msgstr " minutes"
 
 #: extension.js:771
 msgid "Caffeine enabled"
-msgstr "Caffeine est activé"
+msgstr "Caféine est activé"
 
 #: extension.js:773
 msgid "Night Light paused"
@@ -45,47 +49,47 @@ msgstr "Mode nuit suspendu"
 
 #: extension.js:778
 msgid "Caffeine disabled"
-msgstr "Caffeine est désactivé"
+msgstr "Caféine est désactivé"
 
 #: extension.js:780
 msgid "Night Light resumed"
 msgstr "Mode nuit réactivé"
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr "Applications"
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr "Mode de déclenchement"
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr "En cours d'exécution"
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr "Focalisé"
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr "Bureau actif"
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 msgid "Apps trigger Caffeine mode"
-msgstr "Mode de déclenchement applicatif de Caffeine"
+msgstr "Mode de déclenchement applicatif de Caféine"
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Spécifier la façon dont les applications vont déclencher Caffeine"
+msgstr "Spécifier la façon dont les applications vont déclencher Caféine"
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "Ajouter"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
-msgstr "Applications qui déclenchent Caffeine"
+msgstr "Applications qui déclenchent Caféine"
 
 #: preferences/displayPage.js:33 preferences/displayPage.js:43
 msgid "Display"
@@ -105,11 +109,11 @@ msgstr "Jamais"
 
 #: preferences/displayPage.js:52
 msgid "Show status indicator in top panel"
-msgstr "Afficher l’indicateur Caffeine dans la barre supérieure"
+msgstr "Afficher l’indicateur Caféine dans la barre supérieure"
 
 #: preferences/displayPage.js:53
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Activer ou désactiver l’icône de Caffeine dans la barre supérieure"
+msgstr "Activer ou désactiver l’icône de Caféine dans la barre supérieure"
 
 #: preferences/displayPage.js:64
 msgid "Show timer in top panel"
@@ -125,7 +129,7 @@ msgstr "Notifications"
 
 #: preferences/displayPage.js:77
 msgid "Enable notifications when Caffeine is enabled or disabled"
-msgstr "Activer les notifications quand Caffeine est activé ou désactivé"
+msgstr "Activer les notifications quand Caféine est activé ou désactivé"
 
 #: preferences/displayPage.js:99
 msgid "Status indicator position"
@@ -172,7 +176,7 @@ msgstr "Suspendre et réactiver le Mode nuit"
 
 #: preferences/generalPage.js:92
 msgid "Toggles the night light together with Caffeine's state"
-msgstr "Commute le Mode nuit en fonction de l’état de Caffeine"
+msgstr "Commute le Mode nuit en fonction de l’état de Caféine"
 
 #: preferences/generalPage.js:103
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
@@ -181,7 +185,7 @@ msgstr "Autoriser la mise en veille de l'écran seulement"
 
 #: preferences/generalPage.js:104
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "Autoriser la mise en veille de l'écran quand Caffeine est activé"
+msgstr "Autoriser la mise en veille de l'écran quand Caféine est activé"
 
 #: preferences/generalPage.js:119
 msgid "Timer"
@@ -225,7 +229,7 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 msgid "Store caffeine toggle state"
-msgstr "Enregistrer l’état de Caffeine"
+msgstr "Enregistrer l’état de Caféine"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
@@ -243,7 +247,7 @@ msgstr "Index de selection des durées du minuteur"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Rétablir l’état utilisateur de Caffeine"
+msgstr "Rétablir l’état utilisateur de Caféine"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -251,7 +255,7 @@ msgstr "Afficher l’indicateur"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 msgid "Show the indicator on the top panel"
-msgstr "Afficher Caffeine dans la barre supérieure"
+msgstr "Afficher Caféine dans la barre supérieure"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 msgid "Show notifications"
@@ -281,11 +285,11 @@ msgstr "Contrôle du Mode nuit"
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
-"Définir la manière dont Caffeine interagit avec les réglages du Mode nuit."
+"Définir la manière dont Caféine interagit avec les réglages du Mode nuit."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
-msgstr "Activer les notifications quand Caffeine est activé ou désactivé"
+msgstr "Activer les notifications quand Caféine est activé ou désactivé"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
@@ -297,7 +301,7 @@ msgstr "Sélection de la méthode de déclenchement par les applications"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
-msgstr "Raccourci pour commuter Caffeine."
+msgstr "Raccourci pour commuter Caféine."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"

--- a/caffeine@patapon.info/locale/hu.po
+++ b/caffeine@patapon.info/locale/hu.po
@@ -12,6 +12,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.3.1\n"
 
+#: extension.js:160
+msgid "Caffeine"
+msgstr "Koffein"
+
 #: extension.js:177 extension.js:622
 msgid "Caffeine Timer"
 msgstr "Koffein időzítő"
@@ -40,39 +44,39 @@ msgstr "Koffein letiltva"
 msgid "Night Light resumed"
 msgstr "Éjszakai fény folytatva"
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr "Alkalmazások"
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr "Aktiválási mód"
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr "Futtatás"
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr "Fókusz"
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr "Aktív munkaterület"
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 msgid "Apps trigger Caffeine mode"
 msgstr "Alkalmazások Koffeint aktiváló módja"
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 msgid "Choose the way apps will trigger Caffeine"
 msgstr "Alkalmazások ebben a módban fogják aktiválni a Koffeint"
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "Hozzáadás"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
 msgstr "Alkalmazások, amelyek aktiválják a Koffeint"
 

--- a/caffeine@patapon.info/locale/hu.po
+++ b/caffeine@patapon.info/locale/hu.po
@@ -12,35 +12,35 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.3.1\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "Koffein"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr "Koffein időzítő"
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr "Végtelen"
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr " perc"
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr "Koffein engedélyezve"
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr "Éjszakai fény szüneteltetve"
 
-#: extension.js:778
+#: extension.js:788
 msgid "Caffeine disabled"
 msgstr "Koffein letiltva"
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr "Éjszakai fény folytatva"
 
@@ -88,11 +88,13 @@ msgstr "Megjelenés"
 msgid "Only when active"
 msgstr "Csak aktív állapotban"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "Mindig"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "Soha"
 
@@ -128,77 +130,77 @@ msgstr "Állapotjelző pozíciója"
 msgid "The position relative of indicator icon to other items"
 msgstr "Az állapotjelző pozíciója más elemkhez képest"
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr "A listán szereplő alkalmazásokhoz"
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr "Általános"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr "Viselkedés"
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 msgid "Enable for fullscreen apps"
 msgstr "Engedélyezés teljes képernyős alkalmazásokhoz"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "Automatikus engedélyezés, amikor egy alkalmazás teljes képernyős módba lép"
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr "Állapot megjegyzése"
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 msgid "Remember the last state across sessions and reboots"
 msgstr "Legutóbbi állapot megjegyzése munkameneteken és újraindításokon át"
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr "A listán szereplő alkalmazásokhoz"
+
+#: preferences/generalPage.js:85
 msgid "Pause and resume Night Light"
 msgstr "Éjszakai fény szüneteltetése és folytatása"
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Éjszakai fény átváltása a Koffein állapotával együtt"
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "Képernyő elsötétítés engedélyezése"
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Képernyő kikapcsolásának engedélyezése Koffein engeélyezése közben"
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr "Visszaszámláló"
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr "Időtartamok"
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr "Gyorsbillentyű"
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr "Átváltás gyorsbillentyűje"
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr "A törléshez használja a Backspace billentyűt"
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr "Kiválasztható "
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr "Új kombináció…"
 

--- a/caffeine@patapon.info/locale/it_IT.po
+++ b/caffeine@patapon.info/locale/it_IT.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2023-01-13 14:43+0200\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Giuseppe Pignataro (Fastbyte01) <rogepix@gmail.com>\n"
@@ -17,35 +17,35 @@ msgstr ""
 "X-Generator: Poedit 2.0.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "Caffeina"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr "Caffeina Timer"
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr "Infinito"
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr " minuti"
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr "Caffeina abilitata"
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr "Luce notturna in pausa"
 
-#: extension.js:778
+#: extension.js:788
 msgid "Caffeine disabled"
 msgstr "Caffeina disabilitato"
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr "Luce notturna ripristinata"
 
@@ -93,11 +93,13 @@ msgstr "Schermo"
 msgid "Only when active"
 msgstr "Solo attivo"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "Sempre"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "Mai"
 
@@ -134,77 +136,77 @@ msgid "The position relative of indicator icon to other items"
 msgstr ""
 "La posizione relativa dell'icona dell'indicatore rispetto ad altri elementi"
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr "Per le applicazioni in elenco"
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr "Generali"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr "Comportamento"
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 msgid "Enable for fullscreen apps"
 msgstr "Abilita per le app a schermo intero"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "Abilita automaticamente quando un'app entra in modalità schermo intero"
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr "Ricorda stato"
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 msgid "Remember the last state across sessions and reboots"
 msgstr "Ricorda l'ultimo stato tra sessioni e riavvii"
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr "Per le applicazioni in elenco"
+
+#: preferences/generalPage.js:85
 msgid "Pause and resume Night Light"
 msgstr "Mostra notifiche quando abilitato/disabilitato"
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Attiva la modalità notturna insieme allo stato di Caffeina"
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "Consenti schermo vuoto"
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Consenti lo spegnimento dello schermo quando la Caffeina è abilitata"
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr ""
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr "Durate"
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr "Scorciatoia"
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr "Attiva/disattiva la scorciatoia"
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr "Usa Backspace per cancellare"
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr "Impostato su "
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr "Nuovo acceleratore…"
 

--- a/caffeine@patapon.info/locale/it_IT.po
+++ b/caffeine@patapon.info/locale/it_IT.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2023-01-13 14:43+0200\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Giuseppe Pignataro (Fastbyte01) <rogepix@gmail.com>\n"
@@ -17,10 +17,13 @@ msgstr ""
 "X-Generator: Poedit 2.0.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
+#: extension.js:160
+msgid "Caffeine"
+msgstr "Caffeina"
+
 #: extension.js:177 extension.js:622
-#, fuzzy
 msgid "Caffeine Timer"
-msgstr "Caffeine disabilitato"
+msgstr "Caffeina Timer"
 
 #: extension.js:215
 msgid "Infinite"
@@ -32,7 +35,7 @@ msgstr " minuti"
 
 #: extension.js:771
 msgid "Caffeine enabled"
-msgstr "Caffeine abilitata"
+msgstr "Caffeina abilitata"
 
 #: extension.js:773
 msgid "Night Light paused"
@@ -40,47 +43,47 @@ msgstr "Luce notturna in pausa"
 
 #: extension.js:778
 msgid "Caffeine disabled"
-msgstr "Caffeine disabilitato"
+msgstr "Caffeina disabilitato"
 
 #: extension.js:780
 msgid "Night Light resumed"
 msgstr "Luce notturna ripristinata"
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr "Applicazioni"
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr "Modalità di attivazione"
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr "In esecuzione"
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr ""
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr "Area di lavoro attiva"
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 msgid "Apps trigger Caffeine mode"
-msgstr "Le app che attivano la modalità Caffeine"
+msgstr "Le app che attivano la modalità Caffeina"
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Scegli il modo in cui le app attiveranno Caffeine"
+msgstr "Scegli il modo in cui le app attiveranno Caffeina"
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "Aggiungi"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
-msgstr "Applicazioni che abilitano caffeine"
+msgstr "Applicazioni che abilitano Caffeina"
 
 #: preferences/displayPage.js:33 preferences/displayPage.js:43
 msgid "Display"
@@ -104,7 +107,7 @@ msgstr "Mostra l'indicatore di stato nel pannello superiore"
 
 #: preferences/displayPage.js:53
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Abilita o disabilita l'icona Caffeine nel pannello superiore"
+msgstr "Abilita o disabilita l'icona Caffeina nel pannello superiore"
 
 #: preferences/displayPage.js:64
 msgid "Show timer in top panel"
@@ -120,7 +123,7 @@ msgstr "Notifiche"
 
 #: preferences/displayPage.js:77
 msgid "Enable notifications when Caffeine is enabled or disabled"
-msgstr "Abilita le notifiche quando Caffeine è abilitata o disabilitata"
+msgstr "Abilita le notifiche quando Caffeina è abilitata o disabilitata"
 
 #: preferences/displayPage.js:99
 msgid "Status indicator position"
@@ -165,7 +168,7 @@ msgstr "Mostra notifiche quando abilitato/disabilitato"
 
 #: preferences/generalPage.js:92
 msgid "Toggles the night light together with Caffeine's state"
-msgstr "Attiva la modalità notturna insieme allo stato di Caffeine"
+msgstr "Attiva la modalità notturna insieme allo stato di Caffeina"
 
 #: preferences/generalPage.js:103
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
@@ -174,7 +177,7 @@ msgstr "Consenti schermo vuoto"
 
 #: preferences/generalPage.js:104
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "Consenti lo spegnimento dello schermo quando la Caffeine è abilitata"
+msgstr "Consenti lo spegnimento dello schermo quando la Caffeina è abilitata"
 
 #: preferences/generalPage.js:119
 msgid "Timer"
@@ -218,7 +221,7 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 msgid "Store caffeine toggle state"
-msgstr "Memorizza lo stato di attivazione/disattivazione di Caffeine"
+msgstr "Memorizza lo stato di attivazione/disattivazione di Caffeina"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
@@ -236,7 +239,7 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Ripristina lo stato di caffeine"
+msgstr "Ripristina lo stato di Caffeina"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -274,12 +277,12 @@ msgstr "Modalità di controllo della modalità notturna"
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
-"Imposta il modo in cui caffeine interagisce con l'impostazione della "
+"Imposta il modo in cui Caffeina interagisce con l'impostazione della "
 "Modalità notturna."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
-msgstr "Consenti lo spegnimento dello schermo quando Caffeine è abilitata."
+msgstr "Consenti lo spegnimento dello schermo quando Caffeina è abilitata."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
@@ -291,7 +294,7 @@ msgstr "Imposta il metodo di attivazione per le app."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
-msgstr "Scorciatoia per attivare/disattivare Caffeine."
+msgstr "Scorciatoia per attivare/disattivare Caffeina."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"

--- a/caffeine@patapon.info/locale/ja.po
+++ b/caffeine@patapon.info/locale/ja.po
@@ -3,8 +3,8 @@ msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-08-15 00:10+0200\n"
-"PO-Revision-Date: 2017-05-05 22:28+0900\n"
-"Last-Translator: Jean-Philippe Braun <eon@patapon.info>\n"
+"PO-Revision-Date: 2023-08-15 12:00+0200\n"
+"Last-Translator: Pakaoraki <pakaoraki@gmx.com>\n"
 "Language-Team: French\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
@@ -22,38 +22,36 @@ msgid "Caffeine"
 msgstr "カフェイン"
 
 #: extension.js:176 extension.js:632
-#, fuzzy
 msgid "Caffeine Timer"
-msgstr "カフェイン "
+msgstr "カフェインタイマー"
 
 #: extension.js:214
 msgid "Infinite"
-msgstr ""
+msgstr "無限"
 
 #: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
-msgstr ""
+msgstr " 分"
 
 #: extension.js:781
 msgid "Caffeine enabled"
-msgstr "Caféine est activé"
+msgstr "カフェイン機能有効"
 
 #: extension.js:783
 msgid "Night Light paused"
-msgstr ""
+msgstr "ナイトライト一時停止"
 
 #: extension.js:788
-#, fuzzy
 msgid "Caffeine disabled"
-msgstr "Caféine est activé"
+msgstr "カフェイン機能無効"
 
 #: extension.js:790
 msgid "Night Light resumed"
-msgstr ""
+msgstr "ナイトライト再開"
 
 #: preferences/appsPage.js:33
 msgid "Apps"
-msgstr ""
+msgstr "アプリ"
 
 #: preferences/appsPage.js:44
 msgid "Trigger mode"
@@ -89,7 +87,7 @@ msgstr ""
 
 #: preferences/displayPage.js:33 preferences/displayPage.js:43
 msgid "Display"
-msgstr ""
+msgstr "ディスプレイ"
 
 #: preferences/displayPage.js:48
 msgid "Only when active"
@@ -108,22 +106,22 @@ msgstr "一度もない"
 #: preferences/displayPage.js:52
 #, fuzzy
 msgid "Show status indicator in top panel"
-msgstr "Caffeine をトップバーに表示する"
+msgstr "カフェイン をトップバーに表示する"
 
 #: preferences/displayPage.js:53
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Caffeine をトップバーに表示する"
+msgstr "カフェイン をトップバーに表示する"
 
 #: preferences/displayPage.js:64
 #, fuzzy
 msgid "Show timer in top panel"
-msgstr "Caffeine をトップバーに表示する"
+msgstr "カフェイン をトップバーに表示する"
 
 #: preferences/displayPage.js:65
 #, fuzzy
 msgid "Enable or disable the timer in the top panel"
-msgstr "Caffeine をトップバーに表示する"
+msgstr "カフェイン をトップバーに表示する"
 
 #: preferences/displayPage.js:76
 #, fuzzy
@@ -137,7 +135,7 @@ msgstr ""
 #: preferences/displayPage.js:99
 #, fuzzy
 msgid "Status indicator position"
-msgstr "Caffeine をトップバーに表示する"
+msgstr "カフェイン をトップバーに表示する"
 
 #: preferences/displayPage.js:100
 msgid "The position relative of indicator icon to other items"

--- a/caffeine@patapon.info/locale/ja.po
+++ b/caffeine@patapon.info/locale/ja.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2017-05-05 22:28+0900\n"
 "Last-Translator: Jean-Philippe Braun <eon@patapon.info>\n"
 "Language-Team: French\n"
@@ -17,10 +17,14 @@ msgstr ""
 "X-Generator: Poedit 2.0.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
+#: extension.js:160
+msgid "Caffeine"
+msgstr "カフェイン"
+
 #: extension.js:177 extension.js:622
 #, fuzzy
 msgid "Caffeine Timer"
-msgstr "Caféine est activé"
+msgstr "カフェイン "
 
 #: extension.js:215
 msgid "Infinite"
@@ -47,39 +51,39 @@ msgstr "Caféine est activé"
 msgid "Night Light resumed"
 msgstr ""
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr ""
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr ""
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr ""
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr ""
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr ""
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 msgid "Apps trigger Caffeine mode"
 msgstr ""
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 msgid "Choose the way apps will trigger Caffeine"
 msgstr ""
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "追加"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/ja.po
+++ b/caffeine@patapon.info/locale/ja.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2017-05-05 22:28+0900\n"
 "Last-Translator: Jean-Philippe Braun <eon@patapon.info>\n"
 "Language-Team: French\n"
@@ -17,37 +17,37 @@ msgstr ""
 "X-Generator: Poedit 2.0.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "カフェイン"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 #, fuzzy
 msgid "Caffeine Timer"
 msgstr "カフェイン "
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr ""
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr "Caféine est activé"
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:778
+#: extension.js:788
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Caféine est activé"
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr ""
 
@@ -95,11 +95,13 @@ msgstr ""
 msgid "Only when active"
 msgstr "アクティブ時のみ"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "いつも"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "一度もない"
 
@@ -141,79 +143,79 @@ msgstr "Caffeine をトップバーに表示する"
 msgid "The position relative of indicator icon to other items"
 msgstr ""
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr ""
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "フルスクリーンアプリケーション実行時に有効にする"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr "状態を記憶"
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "再起動後も状態を維持する"
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr ""
+
+#: preferences/generalPage.js:85
 msgid "Pause and resume Night Light"
 msgstr ""
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr ""
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr ""
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr ""
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr ""
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/ko.po
+++ b/caffeine@patapon.info/locale/ko.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2022-09-10 10:53+0900\n"
 "Last-Translator: kuroehanako <kmj10727@gmail.com>\n"
 "Language-Team: \n"
@@ -14,6 +14,10 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 "X-Poedit-Basepath: ../../gnome-shell-extension-caffeine-master\n"
 "X-Poedit-SearchPath-0: .\n"
+
+#: extension.js:160
+msgid "Caffeine"
+msgstr "카페인"
 
 #: extension.js:177 extension.js:622
 msgid "Caffeine Timer"
@@ -45,41 +49,41 @@ msgstr ""
 msgid "Night Light resumed"
 msgstr "야간 모드를 다시 켭니"
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr "프로그램"
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr ""
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr ""
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr ""
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr ""
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 #, fuzzy
 msgid "Apps trigger Caffeine mode"
 msgstr "카페인을 제어할 프로그램"
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 #, fuzzy
 msgid "Choose the way apps will trigger Caffeine"
 msgstr "카페인을 제어할 프로그램"
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr ""
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
 msgstr "카페인을 제어할 프로그램"
 

--- a/caffeine@patapon.info/locale/ko.po
+++ b/caffeine@patapon.info/locale/ko.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2022-09-10 10:53+0900\n"
 "Last-Translator: kuroehanako <kmj10727@gmail.com>\n"
 "Language-Team: \n"
@@ -15,36 +15,36 @@ msgstr ""
 "X-Poedit-Basepath: ../../gnome-shell-extension-caffeine-master\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "카페인"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr ""
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr ""
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:773
+#: extension.js:783
 #, fuzzy
 msgid "Night Light paused"
 msgstr "야간 모드를 멈춥니"
 
-#: extension.js:778
+#: extension.js:788
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:780
+#: extension.js:790
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "야간 모드를 다시 켭니"
@@ -95,11 +95,13 @@ msgstr ""
 msgid "Only when active"
 msgstr "활성화된 경우에만"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "항상"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "안 함"
 
@@ -138,78 +140,78 @@ msgstr "상단 패널에 인디케이터 표시"
 msgid "The position relative of indicator icon to other items"
 msgstr ""
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr "목록에 있는 프로그램만"
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr "일반"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 msgid "Enable for fullscreen apps"
 msgstr "전체 화면 프로그램에서 활성화"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "전체 화면 모드에 진입한 프로그램을 사용할 시 자동으로 활성화합니다."
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr "상태 기억하기"
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 msgid "Remember the last state across sessions and reboots"
 msgstr "세션을 바꾸거나 다시 시작할 때 마지막 상태를 기억합니다."
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr "목록에 있는 프로그램만"
+
+#: preferences/generalPage.js:85
 msgid "Pause and resume Night Light"
 msgstr "야간 모드를 멈추거나 다시 켜기"
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "카페인의 상태에 맞춰 야간 모드를 제어합니다."
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "카페인을 켜고 끌 때마다 알림을 표시합니다."
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr ""
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr ""
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr ""
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/nl.po
+++ b/caffeine@patapon.info/locale/nl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2023-02-07 14:23+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch\n"
@@ -17,35 +17,35 @@ msgstr ""
 "X-Generator: Poedit 3.2.2\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "Cafeïne"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr "Cafeïne-tijdklok"
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr "Onbeperkt"
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr ""
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr "Cafeïne is ingeschakeld"
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr "Nachtlicht is onderbroken"
 
-#: extension.js:778
+#: extension.js:788
 msgid "Caffeine disabled"
 msgstr "Cafeïne is uitgeschakeld"
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr "Nachtlicht is hervat"
 
@@ -93,11 +93,13 @@ msgstr "Weergave"
 msgid "Only when active"
 msgstr "Alleen indien actief"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "Altijd"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "Nooit"
 
@@ -134,78 +136,78 @@ msgstr "Locatie van indicator"
 msgid "The position relative of indicator icon to other items"
 msgstr "De locatie van de indicator ten opzichte van andere items"
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr "Bij toepassingen op de lijst"
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr "Algemeen"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr "Gedrag"
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 msgid "Enable for fullscreen apps"
 msgstr "Inschakelen bij schermvullende toepassingen"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 "Schakel automatisch in als een toepassing de schermvullende modus gebruikt"
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr "Status onthouden"
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 msgid "Remember the last state across sessions and reboots"
 msgstr "Herstel de recentste status na wisselen van sessie en herstarten"
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr "Bij toepassingen op de lijst"
+
+#: preferences/generalPage.js:85
 msgid "Pause and resume Night Light"
 msgstr "Nachtlicht onderbreken en hervatten"
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Schakel nachtlicht tegelijk met Cafeïne in/uit"
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "Scherm uitschakelen"
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Schakel het scherm uit als Cafeïne wordt ingeschakeld"
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr ""
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr ""
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr "Sneltoets"
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr "Aan-/Uitsneltoets"
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr "Druk op backspace om te wissen"
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr ""
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr "Nieuwe sneltoets…"
 

--- a/caffeine@patapon.info/locale/nl.po
+++ b/caffeine@patapon.info/locale/nl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2023-02-07 14:23+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch\n"
@@ -17,10 +17,13 @@ msgstr ""
 "X-Generator: Poedit 3.2.2\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
+#: extension.js:160
+msgid "Caffeine"
+msgstr "Cafeïne"
+
 #: extension.js:177 extension.js:622
-#, fuzzy
 msgid "Caffeine Timer"
-msgstr "Caffeine-tijdklok"
+msgstr "Cafeïne-tijdklok"
 
 #: extension.js:215
 msgid "Infinite"
@@ -32,7 +35,7 @@ msgstr ""
 
 #: extension.js:771
 msgid "Caffeine enabled"
-msgstr "Caffeine is ingeschakeld"
+msgstr "Cafeïne is ingeschakeld"
 
 #: extension.js:773
 msgid "Night Light paused"
@@ -40,47 +43,47 @@ msgstr "Nachtlicht is onderbroken"
 
 #: extension.js:778
 msgid "Caffeine disabled"
-msgstr "Caffeine is uitgeschakeld"
+msgstr "Cafeïne is uitgeschakeld"
 
 #: extension.js:780
 msgid "Night Light resumed"
 msgstr "Nachtlicht is hervat"
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr "Toepassingen"
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr "In-/Uitschakelmodus"
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr "Actief"
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr "Focus"
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr "Actief werkblad"
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 msgid "Apps trigger Caffeine mode"
-msgstr "Toepassingen die Caffeine in-/uitschakelen"
+msgstr "Toepassingen die Cafeïne in-/uitschakelen"
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Geef aan hoe toepassingen Caffeine in-/uitschakelen"
+msgstr "Geef aan hoe toepassingen Cafeïne in-/uitschakelen"
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "Toevoegen"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
-msgstr "Toepassingen die Caffeine in-/uitschakelen"
+msgstr "Toepassingen die Cafeïne in-/uitschakelen"
 
 #: preferences/displayPage.js:33 preferences/displayPage.js:43
 msgid "Display"
@@ -104,7 +107,7 @@ msgstr "Indicator tonen op bovenbalk"
 
 #: preferences/displayPage.js:53
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Toon of verberg het Caffeine-pictogram op de bovenbalk"
+msgstr "Toon of verberg het Cafeïne-pictogram op de bovenbalk"
 
 #: preferences/displayPage.js:64
 msgid "Show timer in top panel"
@@ -120,7 +123,7 @@ msgstr "Meldingen"
 
 #: preferences/displayPage.js:77
 msgid "Enable notifications when Caffeine is enabled or disabled"
-msgstr "Toon meldingen als Caffeine wordt in- of uitgeschakeld"
+msgstr "Toon meldingen als Cafeïne wordt in- of uitgeschakeld"
 
 #: preferences/displayPage.js:99
 #, fuzzy
@@ -166,7 +169,7 @@ msgstr "Nachtlicht onderbreken en hervatten"
 
 #: preferences/generalPage.js:92
 msgid "Toggles the night light together with Caffeine's state"
-msgstr "Schakel nachtlicht tegelijk met Caffeine in/uit"
+msgstr "Schakel nachtlicht tegelijk met Cafeïne in/uit"
 
 #: preferences/generalPage.js:103
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
@@ -175,7 +178,7 @@ msgstr "Scherm uitschakelen"
 
 #: preferences/generalPage.js:104
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "Schakel het scherm uit als Caffeine wordt ingeschakeld"
+msgstr "Schakel het scherm uit als Cafeïne wordt ingeschakeld"
 
 #: preferences/generalPage.js:119
 msgid "Timer"
@@ -254,7 +257,7 @@ msgstr "Meldingen tonen"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:58
 msgid "Show notifications when enabled/disabled"
-msgstr "Toon meldingen als Caffeine wordt in- of uitgeschakeld"
+msgstr "Toon meldingen als Cafeïne wordt in- of uitgeschakeld"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:62
 msgid "Show timer"
@@ -275,7 +278,7 @@ msgstr "Nachtlichtbediening"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
-msgstr "Geef aan hoe Caffeine dient om te gaan met de nachtlichtinstelling."
+msgstr "Geef aan hoe Cafeïne dient om te gaan met de nachtlichtinstelling."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
@@ -291,7 +294,7 @@ msgstr "Stel de aan-/uitmethode van toepassingen in."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
-msgstr "Sneltoets om Caffeine aan/uit te zetten."
+msgstr "Sneltoets om Cafeïne aan/uit te zetten."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"

--- a/caffeine@patapon.info/locale/pl.po
+++ b/caffeine@patapon.info/locale/pl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2016-10-02 17:24+0100\n"
 "Last-Translator: Piotr Wittchen <piotr@wittchen.biz.pl>\n"
 "Language-Team: Polish\n"
@@ -17,10 +17,13 @@ msgstr ""
 "X-Generator: Vim\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
+#: extension.js:160
+msgid "Caffeine"
+msgstr "Kofeina"
+
 #: extension.js:177 extension.js:622
-#, fuzzy
 msgid "Caffeine Timer"
-msgstr "Caffeine włączone"
+msgstr "Kofeina Regulator czasowy"
 
 #: extension.js:215
 msgid "Infinite"
@@ -32,7 +35,7 @@ msgstr ""
 
 #: extension.js:771
 msgid "Caffeine enabled"
-msgstr "Caffeine włączone"
+msgstr "Kofeina włączone"
 
 #: extension.js:773
 msgid "Night Light paused"
@@ -41,45 +44,45 @@ msgstr ""
 #: extension.js:778
 #, fuzzy
 msgid "Caffeine disabled"
-msgstr "Caffeine włączone"
+msgstr "Kofeina włączone"
 
 #: extension.js:780
 msgid "Night Light resumed"
 msgstr ""
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr ""
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr ""
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr ""
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr ""
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr ""
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 msgid "Apps trigger Caffeine mode"
 msgstr ""
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 msgid "Choose the way apps will trigger Caffeine"
 msgstr ""
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "Dodaj"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
 msgstr ""
 
@@ -102,22 +105,22 @@ msgstr "Nigdy"
 #: preferences/displayPage.js:52
 #, fuzzy
 msgid "Show status indicator in top panel"
-msgstr "Pokazuj Caffeine w górnym panelu"
+msgstr "Pokazuj Kofeina w górnym panelu"
 
 #: preferences/displayPage.js:53
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Pokazuj Caffeine w górnym panelu"
+msgstr "Pokazuj Kofeina w górnym panelu"
 
 #: preferences/displayPage.js:64
 #, fuzzy
 msgid "Show timer in top panel"
-msgstr "Pokazuj Caffeine w górnym panelu"
+msgstr "Pokazuj Kofeina w górnym panelu"
 
 #: preferences/displayPage.js:65
 #, fuzzy
 msgid "Enable or disable the timer in the top panel"
-msgstr "Pokazuj Caffeine w górnym panelu"
+msgstr "Pokazuj Kofeina w górnym panelu"
 
 #: preferences/displayPage.js:76
 #, fuzzy
@@ -131,7 +134,7 @@ msgstr ""
 #: preferences/displayPage.js:99
 #, fuzzy
 msgid "Status indicator position"
-msgstr "Pokazuj Caffeine w górnym panelu"
+msgstr "Pokazuj Kofeina w górnym panelu"
 
 #: preferences/displayPage.js:100
 msgid "The position relative of indicator icon to other items"
@@ -251,7 +254,7 @@ msgstr ""
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 #, fuzzy
 msgid "Show the indicator on the top panel"
-msgstr "Pokazuj Caffeine w górnym panelu"
+msgstr "Pokazuj Kofeina w górnym panelu"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 #, fuzzy

--- a/caffeine@patapon.info/locale/pl.po
+++ b/caffeine@patapon.info/locale/pl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2016-10-02 17:24+0100\n"
 "Last-Translator: Piotr Wittchen <piotr@wittchen.biz.pl>\n"
 "Language-Team: Polish\n"
@@ -17,36 +17,36 @@ msgstr ""
 "X-Generator: Vim\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "Kofeina"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr "Kofeina Regulator czasowy"
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr ""
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr "Kofeina włączone"
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:778
+#: extension.js:788
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Kofeina włączone"
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr ""
 
@@ -94,11 +94,13 @@ msgstr ""
 msgid "Only when active"
 msgstr "Tylko gdy aktywny"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "Zawsze"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "Nigdy"
 
@@ -140,78 +142,78 @@ msgstr "Pokazuj Kofeina w górnym panelu"
 msgid "The position relative of indicator icon to other items"
 msgstr ""
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr ""
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Włącz kiedy aplikacja jest uruchomiona w trybie pełnoekranowym"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr ""
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 msgid "Remember the last state across sessions and reboots"
 msgstr ""
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr ""
+
+#: preferences/generalPage.js:85
 msgid "Pause and resume Night Light"
 msgstr ""
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr ""
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr ""
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr ""
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr ""
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/pr_BR.po
+++ b/caffeine@patapon.info/locale/pr_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2020-02-25 20:16-0300\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
 "Language-Team: Brazilian Portuguese <gnome-pt_br-list@gnome.org>\n"
@@ -22,10 +22,13 @@ msgstr ""
 "X-Generator: Gtranslator 3.32.0\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
+#: extension.js:160
+msgid "Caffeine"
+msgstr "Cafeína"
+
 #: extension.js:177 extension.js:622
-#, fuzzy
 msgid "Caffeine Timer"
-msgstr "Temporizador do Caffeine"
+msgstr "Temporizador do Cafeína"
 
 #: extension.js:215
 msgid "Infinite"
@@ -37,56 +40,55 @@ msgstr ""
 
 #: extension.js:771
 msgid "Caffeine enabled"
-msgstr "Caffeine ativado"
+msgstr "Cafeína ativado"
 
 #: extension.js:773
 msgid "Night Light paused"
 msgstr "Luz Noturna pausado"
 
 #: extension.js:778
-#, fuzzy
 msgid "Caffeine disabled"
-msgstr "Caffeine desativado"
+msgstr "Cafeína desativado"
 
 #: extension.js:780
 msgid "Night Light resumed"
 msgstr "Luz Noturna resumido"
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr "Aplicativos"
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr "Modo de Gatilho"
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr "Executando"
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr "Em Foco"
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr "Área de Trabalho Ativa"
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 msgid "Apps trigger Caffeine mode"
-msgstr "Aplicativos que ativam o modo Caffeine"
+msgstr "Aplicativos que ativam o modo Cafeína"
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Escolha a maneira que os aplicativos irão ativar o Caffeine"
+msgstr "Escolha a maneira que os aplicativos irão ativar o Cafeína"
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "Adicionar"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
-msgstr "Aplicativos que ativam o modo Caffeine"
+msgstr "Aplicativos que ativam o modo Cafeína"
 
 #: preferences/displayPage.js:33 preferences/displayPage.js:43
 msgid "Display"
@@ -117,7 +119,7 @@ msgstr "Mostrar o indicador no painel superior"
 #: preferences/displayPage.js:64
 #, fuzzy
 msgid "Show timer in top panel"
-msgstr "Mostrar Caffeine no painel superior"
+msgstr "Mostrar Cafeína no painel superior"
 
 #: preferences/displayPage.js:65
 #, fuzzy
@@ -180,7 +182,7 @@ msgstr "Mostra notificações quando ativado/desativado"
 
 #: preferences/generalPage.js:92
 msgid "Toggles the night light together with Caffeine's state"
-msgstr "Alternar Luz Noturna junto do estado do Caffeine"
+msgstr "Alternar Luz Noturna junto do estado do Cafeína"
 
 #: preferences/generalPage.js:103
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
@@ -190,7 +192,7 @@ msgstr "Permitir tela desligada"
 #: preferences/generalPage.js:104
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "Permitir desligar a tela quando o Caffeine está ativado"
+msgstr "Permitir desligar a tela quando o Cafeína está ativado"
 
 #: preferences/generalPage.js:119
 msgid "Timer"
@@ -235,11 +237,11 @@ msgstr ""
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 #, fuzzy
 msgid "Store caffeine toggle state"
-msgstr "Armazenar estado do caffeine do usuário"
+msgstr "Armazenar estado do Cafeína do usuário"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
-msgstr "Armazenar estado do caffeine do usuário"
+msgstr "Armazenar estado do Cafeína do usuário"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
@@ -254,7 +256,7 @@ msgstr "Especifique o tempo do temporizador em minutos"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Restaurar estado do caffeine"
+msgstr "Restaurar estado do Cafeína"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -293,7 +295,7 @@ msgstr "Modo de controle da Luz Noturna"
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
-"Configure a maneira que o Caffeine interage com a configuração da Luz Noturna"
+"Configure a maneira que o Cafeína interage com a configuração da Luz Noturna"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 #, fuzzy
@@ -310,7 +312,7 @@ msgstr "Configure o metodo de gatilho para aplicativos"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
-msgstr "Atalho para alterar o Caffeine"
+msgstr "Atalho para alterar o Cafeína"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"

--- a/caffeine@patapon.info/locale/pr_BR.po
+++ b/caffeine@patapon.info/locale/pr_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2020-02-25 20:16-0300\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
 "Language-Team: Brazilian Portuguese <gnome-pt_br-list@gnome.org>\n"
@@ -22,35 +22,35 @@ msgstr ""
 "X-Generator: Gtranslator 3.32.0\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "Cafeína"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr "Temporizador do Cafeína"
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr "Infinito"
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr ""
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr "Cafeína ativado"
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr "Luz Noturna pausado"
 
-#: extension.js:778
+#: extension.js:788
 msgid "Caffeine disabled"
 msgstr "Cafeína desativado"
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr "Luz Noturna resumido"
 
@@ -98,11 +98,13 @@ msgstr "Tela"
 msgid "Only when active"
 msgstr "Somente ativo"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "Sempre"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "Nunca"
 
@@ -145,81 +147,81 @@ msgstr "Mostrar o indicador no painel superior"
 msgid "The position relative of indicator icon to other items"
 msgstr "Posição do indicador em relação aos outros icones"
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr "Para aplicativos na lista"
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr "Geral"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr "Comportamento"
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Ativar enquanto um aplicativo em tela cheia estiver executando"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr "Lembrar estado"
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "Restaurar estado entre reinicializações"
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr "Para aplicativos na lista"
+
+#: preferences/generalPage.js:85
 #, fuzzy
 msgid "Pause and resume Night Light"
 msgstr "Mostra notificações quando ativado/desativado"
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Alternar Luz Noturna junto do estado do Cafeína"
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "Permitir tela desligada"
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Permitir desligar a tela quando o Cafeína está ativado"
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr ""
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr ""
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr "Atalho"
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr "Atalho para alternar"
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr "Use Backspace para limpar"
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr ""
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr "Nova combinação..."
 

--- a/caffeine@patapon.info/locale/pt_PT.po
+++ b/caffeine@patapon.info/locale/pt_PT.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2016-12-02 10:01+0100\n"
 "Last-Translator: Steeven Lopes <steevenlopes@outlook.com>\n"
 "Language-Team: Portuguese\n"
@@ -17,36 +17,36 @@ msgstr ""
 "X-Generator: Poedit 1.6.10\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "Cafeína"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr "Temporizador do Cafeína"
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr ""
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr "Cafeína ativado"
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:778
+#: extension.js:788
 #, fuzzy
 msgid "Caffeine disabled"
 msgstr "Cafeína ativado"
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr ""
 
@@ -94,11 +94,13 @@ msgstr ""
 msgid "Only when active"
 msgstr "Somente ativo"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "Sempre"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "Nunca"
 
@@ -140,78 +142,78 @@ msgstr "Mostrar Cafeína no painel superior"
 msgid "The position relative of indicator icon to other items"
 msgstr ""
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr ""
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Ativar quando uma aplicação estiver a correr no modo ecrã inteiro"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr ""
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 msgid "Remember the last state across sessions and reboots"
 msgstr ""
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr ""
+
+#: preferences/generalPage.js:85
 msgid "Pause and resume Night Light"
 msgstr ""
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr ""
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr ""
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr ""
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr ""
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/pt_PT.po
+++ b/caffeine@patapon.info/locale/pt_PT.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2016-12-02 10:01+0100\n"
 "Last-Translator: Steeven Lopes <steevenlopes@outlook.com>\n"
 "Language-Team: Portuguese\n"
@@ -17,10 +17,13 @@ msgstr ""
 "X-Generator: Poedit 1.6.10\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
+#: extension.js:160
+msgid "Caffeine"
+msgstr "Cafeína"
+
 #: extension.js:177 extension.js:622
-#, fuzzy
 msgid "Caffeine Timer"
-msgstr "Caffeine ativado"
+msgstr "Temporizador do Cafeína"
 
 #: extension.js:215
 msgid "Infinite"
@@ -32,7 +35,7 @@ msgstr ""
 
 #: extension.js:771
 msgid "Caffeine enabled"
-msgstr "Caffeine ativado"
+msgstr "Cafeína ativado"
 
 #: extension.js:773
 msgid "Night Light paused"
@@ -41,45 +44,45 @@ msgstr ""
 #: extension.js:778
 #, fuzzy
 msgid "Caffeine disabled"
-msgstr "Caffeine ativado"
+msgstr "Cafeína ativado"
 
 #: extension.js:780
 msgid "Night Light resumed"
 msgstr ""
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr ""
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr ""
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr ""
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr ""
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr ""
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 msgid "Apps trigger Caffeine mode"
 msgstr ""
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 msgid "Choose the way apps will trigger Caffeine"
 msgstr ""
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "Adicionar"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
 msgstr ""
 
@@ -102,22 +105,22 @@ msgstr "Nunca"
 #: preferences/displayPage.js:52
 #, fuzzy
 msgid "Show status indicator in top panel"
-msgstr "Mostrar Caffeine no painel superior"
+msgstr "Mostrar Cafeína no painel superior"
 
 #: preferences/displayPage.js:53
 #, fuzzy
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Mostrar Caffeine no painel superior"
+msgstr "Mostrar Cafeína no painel superior"
 
 #: preferences/displayPage.js:64
 #, fuzzy
 msgid "Show timer in top panel"
-msgstr "Mostrar Caffeine no painel superior"
+msgstr "Mostrar Cafeína no painel superior"
 
 #: preferences/displayPage.js:65
 #, fuzzy
 msgid "Enable or disable the timer in the top panel"
-msgstr "Mostrar Caffeine no painel superior"
+msgstr "Mostrar Cafeína no painel superior"
 
 #: preferences/displayPage.js:76
 #, fuzzy
@@ -131,7 +134,7 @@ msgstr ""
 #: preferences/displayPage.js:99
 #, fuzzy
 msgid "Status indicator position"
-msgstr "Mostrar Caffeine no painel superior"
+msgstr "Mostrar Cafeína no painel superior"
 
 #: preferences/displayPage.js:100
 msgid "The position relative of indicator icon to other items"
@@ -251,7 +254,7 @@ msgstr ""
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:53
 #, fuzzy
 msgid "Show the indicator on the top panel"
-msgstr "Mostrar Caffeine no painel superior"
+msgstr "Mostrar Cafeína no painel superior"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:57
 #, fuzzy

--- a/caffeine@patapon.info/locale/ru.po
+++ b/caffeine@patapon.info/locale/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2022-02-08 13:07+0300\n"
 "Last-Translator: Aleksandr Melman <Alexmelman88@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -17,36 +17,36 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "кофеин"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr ""
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr ""
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:773
+#: extension.js:783
 #, fuzzy
 msgid "Night Light paused"
 msgstr "Ночная подсветка"
 
-#: extension.js:778
+#: extension.js:788
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:780
+#: extension.js:790
 #, fuzzy
 msgid "Night Light resumed"
 msgstr "Ночная подсветка"
@@ -97,11 +97,13 @@ msgstr ""
 msgid "Only when active"
 msgstr "Только при активном"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "Всегда"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "Никогда"
 
@@ -140,79 +142,79 @@ msgstr "Показывать индикатор состояния на верх
 msgid "The position relative of indicator icon to other items"
 msgstr ""
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr "Для приложений из списка"
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr "Общие"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 msgid "Enable for fullscreen apps"
 msgstr "Включить для полноэкранных приложений"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 "Автоматически включать, когда приложение переходит в полноэкранный режим"
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr "Запомнить состояние"
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 msgid "Remember the last state across sessions and reboots"
 msgstr "Запомнить последнее состояние после смены сеанса и перезагрузки"
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr "Для приложений из списка"
+
+#: preferences/generalPage.js:85
 msgid "Pause and resume Night Light"
 msgstr "Приостановка и возобновление ночной подсветки"
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Переключение ночной подсветки вместе с состоянием Кофеина"
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Включить уведомления о включении или отключении Кофеина"
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr ""
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr ""
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr ""
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/ru.po
+++ b/caffeine@patapon.info/locale/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2022-02-08 13:07+0300\n"
 "Last-Translator: Aleksandr Melman <Alexmelman88@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -16,6 +16,10 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Generator: Poedit 3.0\n"
 "X-Poedit-SearchPath-0: ../../..\n"
+
+#: extension.js:160
+msgid "Caffeine"
+msgstr "кофеин"
 
 #: extension.js:177 extension.js:622
 msgid "Caffeine Timer"
@@ -47,41 +51,41 @@ msgstr ""
 msgid "Night Light resumed"
 msgstr "Ночная подсветка"
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr "Приложения"
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr ""
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr ""
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr ""
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr ""
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 #, fuzzy
 msgid "Apps trigger Caffeine mode"
 msgstr "Приложения, запускающие действие Кофеина"
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 #, fuzzy
 msgid "Choose the way apps will trigger Caffeine"
 msgstr "Приложения, запускающие действие Кофеина"
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr ""
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
 msgstr "Приложения, запускающие действие Кофеина"
 

--- a/caffeine@patapon.info/locale/sk.po
+++ b/caffeine@patapon.info/locale/sk.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2023-05-28 23:30+0200\n"
 "Last-Translator: Jose Riha <jose1711@gmail.com>\n"
 "Language-Team: Slovak\n"
@@ -17,10 +17,13 @@ msgstr ""
 "X-Generator: Poedit 1.7.3\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
+#: extension.js:160
+msgid "Caffeine"
+msgstr "Kofeín"
+
 #: extension.js:177 extension.js:622
-#, fuzzy
 msgid "Caffeine Timer"
-msgstr "Časovač Caffeine"
+msgstr "Časovač Kofeín"
 
 #: extension.js:215
 msgid "Infinite"
@@ -32,7 +35,7 @@ msgstr " minút"
 
 #: extension.js:771
 msgid "Caffeine enabled"
-msgstr "Caffeine povolený"
+msgstr "Kofeín povolený"
 
 #: extension.js:773
 msgid "Night Light paused"
@@ -40,47 +43,47 @@ msgstr "Nočné svetlo pozastavené"
 
 #: extension.js:778
 msgid "Caffeine disabled"
-msgstr "Caffeine vypnutý"
+msgstr "Kofeín vypnutý"
 
 #: extension.js:780
 msgid "Night Light resumed"
 msgstr "Nočné svetlo obnovené"
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr "Aplikácie"
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr "Režim aktivácie"
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr "Spustené"
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr "Ako aktuálne okno"
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr "Na aktuálnej pracovnej ploche"
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 msgid "Apps trigger Caffeine mode"
 msgstr "Aplikácia aktivuje režim Caffein, keď sú"
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "Vyberte spôsob, ktorým aplikácie aktivujú Caffeine"
+msgstr "Vyberte spôsob, ktorým aplikácie aktivujú Kofeín"
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "Pridať"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
-msgstr "Aplikácie, ktoré aktivujú Caffeine"
+msgstr "Aplikácie, ktoré aktivujú Kofeín"
 
 #: preferences/displayPage.js:33 preferences/displayPage.js:43
 msgid "Display"
@@ -104,7 +107,7 @@ msgstr "Zobraziť indikátor stavu v hornej lište"
 
 #: preferences/displayPage.js:53
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Povoliť alebo zakázať Caffeine v hornej lište"
+msgstr "Povoliť alebo zakázať Kofeín v hornej lište"
 
 #: preferences/displayPage.js:64
 msgid "Show timer in top panel"
@@ -120,7 +123,7 @@ msgstr "Oznámenia"
 
 #: preferences/displayPage.js:77
 msgid "Enable notifications when Caffeine is enabled or disabled"
-msgstr "Povoliť oznámenia, keď je Caffeine povolené alebo zakázané"
+msgstr "Povoliť oznámenia, keď je Kofeín povolené alebo zakázané"
 
 #: preferences/displayPage.js:99
 msgid "Status indicator position"
@@ -164,7 +167,7 @@ msgstr "Pozastaviť a obnoviť Nočné svetlo"
 
 #: preferences/generalPage.js:92
 msgid "Toggles the night light together with Caffeine's state"
-msgstr "Prepne Nočné svetlo spolu so stavom Caffeine"
+msgstr "Prepne Nočné svetlo spolu so stavom Kofeín"
 
 #: preferences/generalPage.js:103
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
@@ -173,7 +176,7 @@ msgstr "Povoliť prázdnu obrazovku"
 
 #: preferences/generalPage.js:104
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "Povoliť vypínanie obrazovky s povoleným Caffeine"
+msgstr "Povoliť vypínanie obrazovky s povoleným Kofeín"
 
 #: preferences/generalPage.js:119
 msgid "Timer"
@@ -215,11 +218,11 @@ msgstr "Zoznam reťazcov obsahujúcich id aplikácie (názov desktop súboru)"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 msgid "Store caffeine toggle state"
-msgstr "Použiť stav zapnutia Caffeine"
+msgstr "Použiť stav zapnutia Kofeín"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
-msgstr "Použiť používateľský stav Caffeine"
+msgstr "Použiť používateľský stav Kofeín"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
@@ -233,7 +236,7 @@ msgstr "Nastavte index rozsahu doby časovača"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Obnoviť stav Caffeine"
+msgstr "Obnoviť stav Kofeín"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -271,11 +274,11 @@ msgstr "Režim riadenia Nočného svetla"
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
 msgstr ""
-"Nastavte spôsob, ktorým Caffeine spolupracuje s nastavením Nočného svetla."
+"Nastavte spôsob, ktorým Kofeín spolupracuje s nastavením Nočného svetla."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
-msgstr "Povoliť vypínanie obrazovky s povoleným Caffeine."
+msgstr "Povoliť vypínanie obrazovky s povoleným Kofeín."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
@@ -287,7 +290,7 @@ msgstr "Nastaviť režim spustenia pre aplikácie."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
-msgstr "Skratka pre prepnutie Caffeine."
+msgstr "Skratka pre prepnutie Kofeín."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"

--- a/caffeine@patapon.info/locale/sk.po
+++ b/caffeine@patapon.info/locale/sk.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2023-05-28 23:30+0200\n"
 "Last-Translator: Jose Riha <jose1711@gmail.com>\n"
 "Language-Team: Slovak\n"
@@ -17,35 +17,35 @@ msgstr ""
 "X-Generator: Poedit 1.7.3\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "Kofeín"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr "Časovač Kofeín"
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr "Nekonečno"
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr " minút"
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr "Kofeín povolený"
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr "Nočné svetlo pozastavené"
 
-#: extension.js:778
+#: extension.js:788
 msgid "Caffeine disabled"
 msgstr "Kofeín vypnutý"
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr "Nočné svetlo obnovené"
 
@@ -93,11 +93,13 @@ msgstr "Displej"
 msgid "Only when active"
 msgstr "Len keď je aktívny"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "Vždy"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "Nikdy"
 
@@ -133,77 +135,77 @@ msgstr "Umiestnenie indikátoru stavu"
 msgid "The position relative of indicator icon to other items"
 msgstr "Relatívne umiestnenie ikony voči ostatným položkám"
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr "Pre aplikácie na zozname"
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr "Všeobecné"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr "Správanie"
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 msgid "Enable for fullscreen apps"
 msgstr "Povoliť pre celoobrazovkové aplikácie"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "Automaticky povoliť, keď aplikácia prejde do režimu celej obrazovky"
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr "Pamätať stav"
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 msgid "Remember the last state across sessions and reboots"
 msgstr "Pamätať si posledný stav medzi sedeniami a reštartami"
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr "Pre aplikácie na zozname"
+
+#: preferences/generalPage.js:85
 msgid "Pause and resume Night Light"
 msgstr "Pozastaviť a obnoviť Nočné svetlo"
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Prepne Nočné svetlo spolu so stavom Kofeín"
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "Povoliť prázdnu obrazovku"
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Povoliť vypínanie obrazovky s povoleným Kofeín"
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr "Časovač"
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr "Doby trvania"
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr "Skratka"
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr "Skratka prepnutia"
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr "Použite backspace pre vymazanie"
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr "Nastavené na "
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr "Nová skratka…"
 

--- a/caffeine@patapon.info/locale/sv.po
+++ b/caffeine@patapon.info/locale/sv.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2018-04-04 20:35+0200\n"
 "Last-Translator: Morgan Antonsson <morgan.antonsson@gmail.com>\n"
 "Language-Team: \n"
@@ -10,6 +10,10 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: extension.js:160
+msgid "Caffeine"
+msgstr "Koffein"
 
 #: extension.js:177 extension.js:622
 msgid "Caffeine Timer"
@@ -39,39 +43,39 @@ msgstr ""
 msgid "Night Light resumed"
 msgstr ""
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr ""
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr ""
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr ""
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr ""
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr ""
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 msgid "Apps trigger Caffeine mode"
 msgstr ""
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 msgid "Choose the way apps will trigger Caffeine"
 msgstr ""
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "Lägg till"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
 msgstr ""
 
@@ -104,7 +108,7 @@ msgstr "Visa indikator i panelen"
 #: preferences/displayPage.js:64
 #, fuzzy
 msgid "Show timer in top panel"
-msgstr "Visa Caffeine i panelen"
+msgstr "Visa koffein i panelen"
 
 #: preferences/displayPage.js:65
 #, fuzzy
@@ -220,11 +224,11 @@ msgstr "En lista av strängar med program-ID:n (skrivbordets filnamn)"
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 #, fuzzy
 msgid "Store caffeine toggle state"
-msgstr "Spara caffeines användarstatus"
+msgstr "Spara koffein användarstatus"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
-msgstr "Spara caffeines användarstatus"
+msgstr "Spara koffein användarstatus"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
@@ -238,7 +242,7 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Återställ caffeine-status"
+msgstr "Återställ koffein-status"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"

--- a/caffeine@patapon.info/locale/sv.po
+++ b/caffeine@patapon.info/locale/sv.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2018-04-04 20:35+0200\n"
 "Last-Translator: Morgan Antonsson <morgan.antonsson@gmail.com>\n"
 "Language-Team: \n"
@@ -11,35 +11,35 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "Koffein"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr ""
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr ""
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr ""
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr ""
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr ""
 
-#: extension.js:778
+#: extension.js:788
 msgid "Caffeine disabled"
 msgstr ""
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr ""
 
@@ -87,11 +87,13 @@ msgstr ""
 msgid "Only when active"
 msgstr "Samo ko je aktiven"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "Nenehno"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "Nikoli"
 
@@ -134,81 +136,81 @@ msgstr "Visa indikator i panelen"
 msgid "The position relative of indicator icon to other items"
 msgstr ""
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr ""
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr ""
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr ""
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 #, fuzzy
 msgid "Enable for fullscreen apps"
 msgstr "Aktivera när ett program använder helskärmsläget"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr ""
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr ""
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 #, fuzzy
 msgid "Remember the last state across sessions and reboots"
 msgstr "Återställ tillstånd efter omstart"
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr ""
+
+#: preferences/generalPage.js:85
 #, fuzzy
 msgid "Pause and resume Night Light"
 msgstr "Visa notifieringar vid aktivering/inaktivering"
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr ""
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr ""
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 #, fuzzy
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Visa notifieringar vid aktivering/inaktivering"
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr ""
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr ""
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr ""
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr ""
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr ""
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr ""
 

--- a/caffeine@patapon.info/locale/tr.po
+++ b/caffeine@patapon.info/locale/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2019-03-21 06:48+0300\n"
 "Last-Translator: Serdar Sağlam <teknomobil@yandex.com>\n"
 "Language-Team: Turkish <gnome-turk@gnome.org>\n"
@@ -18,9 +18,13 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Generator: Gtranslator 3.32.0\n"
 
+#: extension.js:160
+msgid "Caffeine"
+msgstr "Kafein"
+
 #: extension.js:177 extension.js:622
 msgid "Caffeine Timer"
-msgstr "Caffeine Zamanlayıcısı"
+msgstr "Kafein Zamanlayıcısı"
 
 #: extension.js:215
 msgid "Infinite"
@@ -32,7 +36,7 @@ msgstr " dakika"
 
 #: extension.js:771
 msgid "Caffeine enabled"
-msgstr "Caffeine aktif"
+msgstr "Kafein aktif"
 
 #: extension.js:773
 msgid "Night Light paused"
@@ -40,47 +44,47 @@ msgstr "Gece Işığı durduruldu"
 
 #: extension.js:778
 msgid "Caffeine disabled"
-msgstr "Caffeine devre dışı"
+msgstr "Kafein devre dışı"
 
 #: extension.js:780
 msgid "Night Light resumed"
 msgstr "Gece Işığı devam ettirildi"
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr "Uygulamalar"
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr "Tetik Modu"
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr "Çalışıyor"
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr "Odak"
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr "Aktif Çalışma Alanı"
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 msgid "Apps trigger Caffeine mode"
-msgstr "Caffeine modunu tetikleyen uygulamalar"
+msgstr "Kafein modunu tetikleyen uygulamalar"
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 msgid "Choose the way apps will trigger Caffeine"
 msgstr "Uygulamaların Caffeine'ini nasıl tetikleyeceğini seçiniz"
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "Ekle"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
-msgstr "Caffeine'ini tetikleyecek uygulamalar"
+msgstr "Kafein'ini tetikleyecek uygulamalar"
 
 #: preferences/displayPage.js:33 preferences/displayPage.js:43
 msgid "Display"
@@ -104,7 +108,7 @@ msgstr "Göstergeyi üst panelde göster"
 
 #: preferences/displayPage.js:53
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "Caffeine'ini üst paneldeki simge ile aktif et yada devre dışı bırak"
+msgstr "Kafein'ini üst paneldeki simge ile aktif et yada devre dışı bırak"
 
 #: preferences/displayPage.js:64
 msgid "Show timer in top panel"
@@ -120,7 +124,7 @@ msgstr "Bildirimler"
 
 #: preferences/displayPage.js:77
 msgid "Enable notifications when Caffeine is enabled or disabled"
-msgstr "Caffeine aktif yada pasif olduğunda bildirimleri göster"
+msgstr "Kafein aktif yada pasif olduğunda bildirimleri göster"
 
 #: preferences/displayPage.js:99
 msgid "Status indicator position"
@@ -164,7 +168,7 @@ msgstr "Gece Işığı'ını durdur ve devam et"
 
 #: preferences/generalPage.js:92
 msgid "Toggles the night light together with Caffeine's state"
-msgstr "Gece Işığı'nı Caffeine durumuyla birlikte değiştir"
+msgstr "Gece Işığı'nı Kafein durumuyla birlikte değiştir"
 
 #: preferences/generalPage.js:103
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
@@ -173,7 +177,7 @@ msgstr "Boş ekrana izin ver"
 
 #: preferences/generalPage.js:104
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "Caffeine aktif edildiğinde ekranı kapatmaya izin ver"
+msgstr "Kafein aktif edildiğinde ekranı kapatmaya izin ver"
 
 #: preferences/generalPage.js:119
 msgid "Timer"
@@ -216,11 +220,11 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 msgid "Store caffeine toggle state"
-msgstr "Caffeine durumunu sakla"
+msgstr "Kafein durumunu sakla"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
-msgstr "Caffeine kullanıcı durumunu sakla"
+msgstr "Kafein kullanıcı durumunu sakla"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
@@ -234,7 +238,7 @@ msgstr "Zamanlayıcı için süre aralığı dizinini belirtin"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "Caffeine durumunu geri yükle"
+msgstr "Kafein durumunu geri yükle"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -271,11 +275,11 @@ msgstr "Gece Işığı kontrol modu"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
-msgstr "Caffeine'in Gece Işığı ayarıyla etkileşim kurma şeklini ayarlayın."
+msgstr "Kafein'in Gece Işığı ayarıyla etkileşim kurma şeklini ayarlayın."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
-msgstr "Caffeine aktif olduğunda ekranı kapatmaya izin ver"
+msgstr "Kafein aktif olduğunda ekranı kapatmaya izin ver"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
@@ -287,7 +291,7 @@ msgstr "Uygulamalar için tetikleme modunu ayarla"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
-msgstr "Caffeine durumu değiştirmek için kısayol"
+msgstr "Kafein durumu değiştirmek için kısayol"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"

--- a/caffeine@patapon.info/locale/tr.po
+++ b/caffeine@patapon.info/locale/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2019-03-21 06:48+0300\n"
 "Last-Translator: Serdar Sağlam <teknomobil@yandex.com>\n"
 "Language-Team: Turkish <gnome-turk@gnome.org>\n"
@@ -18,35 +18,35 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Generator: Gtranslator 3.32.0\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "Kafein"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr "Kafein Zamanlayıcısı"
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr "Süresiz"
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr " dakika"
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr "Kafein aktif"
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr "Gece Işığı durduruldu"
 
-#: extension.js:778
+#: extension.js:788
 msgid "Caffeine disabled"
 msgstr "Kafein devre dışı"
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr "Gece Işığı devam ettirildi"
 
@@ -94,11 +94,13 @@ msgstr "Ekran"
 msgid "Only when active"
 msgstr "Yalnızca etkin olduğunda"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "Her zaman"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "Hiçbir zaman"
 
@@ -134,77 +136,77 @@ msgstr "Durum göstergesinin konumu"
 msgid "The position relative of indicator icon to other items"
 msgstr "Gösterge simgesinin diğer öğelere göre konumu"
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr "Listedeki uygulamalar için"
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr "Genel"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr "Davranış"
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 msgid "Enable for fullscreen apps"
 msgstr "Tam ekran uygulamalar için aktif et"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "Uygulamalar tam ekran olduğunda otomatik aktif et"
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr "Durumu hatırla"
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 msgid "Remember the last state across sessions and reboots"
 msgstr "Oturumlar ve yeniden başlatmalar arasındaki son durumu hatırla"
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr "Listedeki uygulamalar için"
+
+#: preferences/generalPage.js:85
 msgid "Pause and resume Night Light"
 msgstr "Gece Işığı'ını durdur ve devam et"
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "Gece Işığı'nı Kafein durumuyla birlikte değiştir"
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "Boş ekrana izin ver"
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "Kafein aktif edildiğinde ekranı kapatmaya izin ver"
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr "Zamanlayıcı"
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr "Süreler"
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr "Kısayol"
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr "Kısayolu değiştir"
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr "Temizlemek için klavyedeki geri tuşunu kullan"
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr "Ayarla "
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr "Yeni hızlandırıcı..."
 
@@ -310,8 +312,7 @@ msgid ""
 "Real position offset of status icon in indicator menu that include invisible "
 "one"
 msgstr ""
-"Görünmez içeren gösterge menüsünde durum simgesinin gerçek konum ofseti"
-"bir"
+"Görünmez içeren gösterge menüsünde durum simgesinin gerçek konum ofsetibir"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:108
 msgid "Last item index in indicator menu"

--- a/caffeine@patapon.info/locale/zh_CN.po
+++ b/caffeine@patapon.info/locale/zh_CN.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 18:13+0200\n"
+"POT-Creation-Date: 2023-08-15 00:10+0200\n"
 "PO-Revision-Date: 2022-06-30 11:54-0400\n"
 "Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <debian-l10n-chinese@lists.debian.org>\n"
@@ -17,35 +17,35 @@ msgstr ""
 "X-Generator: Poedit 3.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
-#: extension.js:160
+#: extension.js:159
 msgid "Caffeine"
 msgstr "咖啡因"
 
-#: extension.js:177 extension.js:622
+#: extension.js:176 extension.js:632
 msgid "Caffeine Timer"
 msgstr "咖啡因 定时器"
 
-#: extension.js:215
+#: extension.js:214
 msgid "Infinite"
 msgstr "持续"
 
-#: extension.js:217 extension.js:806 preferences/generalPage.js:218
+#: extension.js:216 extension.js:816 preferences/generalPage.js:212
 msgid " minutes"
 msgstr " 分钟"
 
-#: extension.js:771
+#: extension.js:781
 msgid "Caffeine enabled"
 msgstr "咖啡因 已开启"
 
-#: extension.js:773
+#: extension.js:783
 msgid "Night Light paused"
 msgstr "夜灯已暂停"
 
-#: extension.js:778
+#: extension.js:788
 msgid "Caffeine disabled"
 msgstr "咖啡因 已关闭"
 
-#: extension.js:780
+#: extension.js:790
 msgid "Night Light resumed"
 msgstr "夜灯已恢复"
 
@@ -93,11 +93,13 @@ msgstr "显示"
 msgid "Only when active"
 msgstr "仅在活动时"
 
-#: preferences/displayPage.js:49 preferences/generalPage.js:32
+#: preferences/displayPage.js:49 preferences/generalPage.js:82
+#: preferences/generalPage.js:94
 msgid "Always"
 msgstr "总是"
 
-#: preferences/displayPage.js:50 preferences/generalPage.js:31
+#: preferences/displayPage.js:50 preferences/generalPage.js:81
+#: preferences/generalPage.js:93
 msgid "Never"
 msgstr "从不"
 
@@ -133,77 +135,77 @@ msgstr "在顶部面板显示状态指示器"
 msgid "The position relative of indicator icon to other items"
 msgstr "状态指示器的相对位置"
 
-#: preferences/generalPage.js:33
-msgid "For apps on list"
-msgstr "用于列表上的应用"
-
-#: preferences/generalPage.js:48
+#: preferences/generalPage.js:42
 msgid "General"
 msgstr "常规"
 
-#: preferences/generalPage.js:58
+#: preferences/generalPage.js:52
 msgid "Behavior"
 msgstr "行为"
 
-#: preferences/generalPage.js:67
+#: preferences/generalPage.js:61
 msgid "Enable for fullscreen apps"
 msgstr "为全屏程序启用"
 
-#: preferences/generalPage.js:68
+#: preferences/generalPage.js:62
 msgid "Automatically enable when an app enters fullscreen mode"
 msgstr "在有应用进入全屏模式时自动启用"
 
-#: preferences/generalPage.js:79
+#: preferences/generalPage.js:73
 msgid "Remember state"
 msgstr "记住状态"
 
-#: preferences/generalPage.js:80
+#: preferences/generalPage.js:74
 msgid "Remember the last state across sessions and reboots"
 msgstr "跨会话和重启记住上一次的状态"
 
-#: preferences/generalPage.js:91
+#: preferences/generalPage.js:83 preferences/generalPage.js:95
+msgid "For apps on list"
+msgstr "用于列表上的应用"
+
+#: preferences/generalPage.js:85
 msgid "Pause and resume Night Light"
 msgstr "暂停和恢复夜灯"
 
-#: preferences/generalPage.js:92
+#: preferences/generalPage.js:86
 msgid "Toggles the night light together with Caffeine's state"
 msgstr "随 咖啡因 的状态切换夜灯"
 
-#: preferences/generalPage.js:103
+#: preferences/generalPage.js:97
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
 msgid "Allow screen blank"
 msgstr "允许屏幕保护"
 
-#: preferences/generalPage.js:104
+#: preferences/generalPage.js:98
 msgid "Allow turning off screen when Caffeine is enabled"
 msgstr "允许在 咖啡因 启用时关闭屏幕"
 
-#: preferences/generalPage.js:119
+#: preferences/generalPage.js:113
 msgid "Timer"
 msgstr "计时器"
 
-#: preferences/generalPage.js:124
+#: preferences/generalPage.js:118
 msgid "Durations"
 msgstr "持续"
 
-#: preferences/generalPage.js:168
+#: preferences/generalPage.js:162
 msgid "Shortcut"
 msgstr "快捷键"
 
-#: preferences/generalPage.js:176
+#: preferences/generalPage.js:170
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:87
 msgid "Toggle shortcut"
 msgstr "修改快捷键"
 
-#: preferences/generalPage.js:177
+#: preferences/generalPage.js:171
 msgid "Use Backspace to clear"
 msgstr "使用退格来清除"
 
-#: preferences/generalPage.js:218
+#: preferences/generalPage.js:212
 msgid "Set to "
 msgstr "设置到 "
 
-#: preferences/generalPage.js:265 preferences/generalPage.js:297
+#: preferences/generalPage.js:259 preferences/generalPage.js:291
 msgid "New accelerator…"
 msgstr "新快捷键…"
 

--- a/caffeine@patapon.info/locale/zh_CN.po
+++ b/caffeine@patapon.info/locale/zh_CN.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-caffeine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-09 16:08+0200\n"
+"POT-Creation-Date: 2023-07-09 18:13+0200\n"
 "PO-Revision-Date: 2022-06-30 11:54-0400\n"
 "Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <debian-l10n-chinese@lists.debian.org>\n"
@@ -17,10 +17,13 @@ msgstr ""
 "X-Generator: Poedit 3.1\n"
 "X-Poedit-SearchPath-0: ../../..\n"
 
+#: extension.js:160
+msgid "Caffeine"
+msgstr "咖啡因"
+
 #: extension.js:177 extension.js:622
-#, fuzzy
 msgid "Caffeine Timer"
-msgstr "Caffeine 定时器"
+msgstr "咖啡因 定时器"
 
 #: extension.js:215
 msgid "Infinite"
@@ -32,7 +35,7 @@ msgstr " 分钟"
 
 #: extension.js:771
 msgid "Caffeine enabled"
-msgstr "Caffeine 已开启"
+msgstr "咖啡因 已开启"
 
 #: extension.js:773
 msgid "Night Light paused"
@@ -40,47 +43,47 @@ msgstr "夜灯已暂停"
 
 #: extension.js:778
 msgid "Caffeine disabled"
-msgstr "Caffeine 已关闭"
+msgstr "咖啡因 已关闭"
 
 #: extension.js:780
 msgid "Night Light resumed"
 msgstr "夜灯已恢复"
 
-#: preferences/appsPage.js:34
+#: preferences/appsPage.js:33
 msgid "Apps"
 msgstr "应用"
 
-#: preferences/appsPage.js:45
+#: preferences/appsPage.js:44
 msgid "Trigger mode"
 msgstr "触发模式"
 
-#: preferences/appsPage.js:50
+#: preferences/appsPage.js:49
 msgid "Running"
 msgstr "运行"
 
-#: preferences/appsPage.js:51
+#: preferences/appsPage.js:50
 msgid "Focus"
 msgstr "聚焦"
 
-#: preferences/appsPage.js:52
+#: preferences/appsPage.js:51
 msgid "Active workspace"
 msgstr "活跃工作区"
 
-#: preferences/appsPage.js:54
+#: preferences/appsPage.js:53
 msgid "Apps trigger Caffeine mode"
-msgstr "触发 Caffeine 的应用"
+msgstr "触发 咖啡因 的应用"
 
-#: preferences/appsPage.js:55
+#: preferences/appsPage.js:54
 msgid "Choose the way apps will trigger Caffeine"
-msgstr "触发 Caffeine 的应用"
+msgstr "触发 咖啡因 的应用"
 
-#: preferences/appsPage.js:69
+#: preferences/appsPage.js:68
 msgid "Add"
 msgstr "添加"
 
-#: preferences/appsPage.js:73
+#: preferences/appsPage.js:72
 msgid "Apps that trigger Caffeine"
-msgstr "触发 Caffeine 的应用"
+msgstr "触发 咖啡因 的应用"
 
 #: preferences/displayPage.js:33 preferences/displayPage.js:43
 msgid "Display"
@@ -104,15 +107,15 @@ msgstr "在顶部面板显示状态指示器"
 
 #: preferences/displayPage.js:53
 msgid "Enable or disable the Caffeine icon in the top panel"
-msgstr "在顶部面板启用或禁用 Caffeine 图标"
+msgstr "在顶部面板启用或禁用 咖啡因 图标"
 
 #: preferences/displayPage.js:64
 msgid "Show timer in top panel"
-msgstr "在顶部面板显示 Caffeine 计时器"
+msgstr "在顶部面板显示 咖啡因 计时器"
 
 #: preferences/displayPage.js:65
 msgid "Enable or disable the timer in the top panel"
-msgstr "在顶部面板启用或禁用 Caffeine 计时器"
+msgstr "在顶部面板启用或禁用 咖啡因 计时器"
 
 #: preferences/displayPage.js:76
 msgid "Notifications"
@@ -120,7 +123,7 @@ msgstr "通知"
 
 #: preferences/displayPage.js:77
 msgid "Enable notifications when Caffeine is enabled or disabled"
-msgstr "在 Caffeine 被启用或禁用时显示通知"
+msgstr "在 咖啡因 被启用或禁用时显示通知"
 
 #: preferences/displayPage.js:99
 msgid "Status indicator position"
@@ -164,7 +167,7 @@ msgstr "暂停和恢复夜灯"
 
 #: preferences/generalPage.js:92
 msgid "Toggles the night light together with Caffeine's state"
-msgstr "随 Caffeine 的状态切换夜灯"
+msgstr "随 咖啡因 的状态切换夜灯"
 
 #: preferences/generalPage.js:103
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:77
@@ -173,7 +176,7 @@ msgstr "允许屏幕保护"
 
 #: preferences/generalPage.js:104
 msgid "Allow turning off screen when Caffeine is enabled"
-msgstr "允许在 Caffeine 启用时关闭屏幕"
+msgstr "允许在 咖啡因 启用时关闭屏幕"
 
 #: preferences/generalPage.js:119
 msgid "Timer"
@@ -215,11 +218,11 @@ msgstr "一个字符串的列表，每个字符串包含一个应用程序 id（
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:27
 msgid "Store caffeine toggle state"
-msgstr "保存 caffeine 状态"
+msgstr "保存 咖啡因 状态"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:32
 msgid "Store caffeine user state"
-msgstr "保存 caffeine 状态"
+msgstr "保存 咖啡因 状态"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:37
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:38
@@ -233,7 +236,7 @@ msgstr "指定计时器的持续时间"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:47
 msgid "Restore caffeine state"
-msgstr "恢复 caffeine 状态"
+msgstr "恢复 咖啡因 状态"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:52
 msgid "Show indicator"
@@ -270,11 +273,11 @@ msgstr "夜灯控制模式"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:73
 msgid "Set the way Caffeine interacts with the Night light setting."
-msgstr "设置 Caffeine 和夜灯设置交互的方式。"
+msgstr "设置 咖啡因 和夜灯设置交互的方式。"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:78
 msgid "Allow turning off screen when Caffeine is enabled."
-msgstr "允许在 Caffeine 启用时关闭屏幕"
+msgstr "允许在 咖啡因 启用时关闭屏幕"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:82
 msgid "Trigger App control mode"
@@ -286,7 +289,7 @@ msgstr "设置应用的触发方式."
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:88
 msgid "Shortcut to toggle Caffeine."
-msgstr "切换 Caffeine 的快捷键"
+msgstr "切换 咖啡因 的快捷键"
 
 #: schemas/org.gnome.shell.extensions.caffeine.gschema.xml:92
 msgid "Default width for the preferences window"


### PR DESCRIPTION
I noticed that, depend of the language, sometimes 'caffeine' is translated, sometimes not: it could be nice to translate it in all to keep consistency.
Also in Lineageos they translated the menu 'Caffeine', so I thought it could make sens to make this change.

Someone in [#246](https://github.com/eonpatapon/gnome-shell-extension-caffeine/pull/246) had this idea:

> I wonder if i should translate word "Caffeine"?

Let me know if it's something you'd like to see.