### PR TITLE
Fix Gdk.SHIFT_MASK being undefined

### DIFF
--- a/caffeine@patapon.info/preferences/generalPage.js
+++ b/caffeine@patapon.info/preferences/generalPage.js
@@ -371,7 +371,7 @@ const ShortcutSettingWidget = class extends Adw.ActionRow {
     }
 
     isValidBinding(mask, keycode, keyval) {
-        return !(mask === 0 || mask === Gdk.SHIFT_MASK && keycode !== 0 &&
+        return !(mask === 0 || mask === Gdk.ModifierType.SHIFT_MASK && keycode !== 0 &&
                  ((keyval >= Gdk.KEY_a && keyval <= Gdk.KEY_z) ||
                      (keyval >= Gdk.KEY_A && keyval <= Gdk.KEY_Z) ||
                      (keyval >= Gdk.KEY_0 && keyval <= Gdk.KEY_9) ||


### PR DESCRIPTION
Bindings such as "SHIFT" + "A" were mistakenly being enabled. I'm not sure if / when it swapped to `Gdk.ModifierType.SHIFT_MASK`, instead of `Gdk.SHIFT_MASK`, but it's the same on both GNOME 43 and 44, the 2 supported versions.

Closes #279