### PR TITLE
GNOME 45 Porting

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,6 +1,8 @@
 extends: #Imports upstream linting rules
  - ./lint/eslintrc-gjs.yml
  - ./lint/eslintrc-shell.yml
+parserOptions:
+  sourceType: module
 rules: #Override some of the upstream rules to match this codebase
   arrow-parens:
    - error

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: awalsh128/cache-apt-pkgs-action@latest
       with:
-        packages: make gettext gnome-shell libglib2.0-bin
+        packages: make gettext gnome-shell
         version: 1.0
 
     - name: Test extension builds from scratch

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ all: build install
 .PHONY: build install clean translations lint lint-fix
 
 build:
-	glib-compile-schemas --strict --targetdir=caffeine@patapon.info/schemas/ caffeine@patapon.info/schemas
 	rm -f $(BUNDLE_PATH)
 	cd $(EXTENSION_DIR); \
 	gnome-extensions pack --force --podir=locale \

--- a/README.md
+++ b/README.md
@@ -11,16 +11,17 @@ Enable / disable auto suspend with quick setting toggle.
 
 ## Version
 
-This extension supports GNOME Shell `3.4` -> `44`
+This extension supports GNOME Shell `3.4` -> `45`
 
-|Branch                   |Version|Compatible Gnome version|
+|Branch                   |Version|Compatible GNOME version|
 |-------------------------|:-----:|------------------------|
-| master                  |    46 | Gnome 43 -> 44         |
-| gnome-shell-40-42       |    42 | Gnome 40 -> 42         |
-| gnome-shell-3.36-3.38   |    37 | Gnome 3.36 -> 3.38     |
-| gnome-shell-3.32-3.34   |    33 | Gnome 3.32 -> 3.34     |
-| gnome-shell-3.10-3.30   |     - | Gnome 3.10 -> 3.30     |
-| gnome-shell-before-3.10 |     - | Gnome 3.4 -> 3.8       |
+| master                  |    50 | GNOME 45               |
+| gnome-shell-43-44       |    49 | GNOME 43 -> 44         |
+| gnome-shell-40-42       |    42 | GNOME 40 -> 42         |
+| gnome-shell-3.36-3.38   |    37 | GNOME 3.36 -> 3.38     |
+| gnome-shell-3.32-3.34   |    33 | GNOME 3.32 -> 3.34     |
+| gnome-shell-3.10-3.30   |     - | GNOME 3.10 -> 3.30     |
+| gnome-shell-before-3.10 |     - | GNOME 3.4 -> 3.8       |
 
 ## Installation From source
 

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -1,7 +1,7 @@
 /* -*- mode: js2 - indent-tabs-mode: nil - js2-basic-offset: 4 -*- */
 /* jshint multistr:true */
 /* jshint esnext:true */
-/* exported enable disable init */
+/* exported CaffeineExtension */
 /**
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -125,8 +125,6 @@ const TIMERS = [
     [30, 45, 60, 75, 80, 'caffeine-long-timer-symbolic'],
     [0, 0, 0, 0, 0, 'caffeine-infinite-timer-symbolic']
 ];
-
-let CaffeineIndicator;
 
 const CaffeineToggle = GObject.registerClass(
 class CaffeineToggle extends QuickSettings.QuickMenuToggle {

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -381,8 +381,10 @@ class Caffeine extends QuickSettings.SystemIndicator {
         this.indicatorIndex = this._settings.get_int(INDICATOR_INDEX);
         this.lastIndicatorPosition = this.indicatorPosition;
 
+        // Add indicator and toggle
+        QuickSettingsMenu.addExternalIndicator(this);
+        QuickSettingsMenu._indicators.remove_actor(this);
         QuickSettingsMenu._indicators.insert_child_at_index(this, this.indicatorIndex);
-        QuickSettingsMenu.addExternalIndicator(this.quickSettingsItems);
 
         this._updateLastIndicatorPosition();
     }

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -129,27 +129,6 @@ const TIMERS = [
 ];
 
 let CaffeineIndicator;
-/*
-* ------- Load custom icon -------
-* hack (for Wayland?) via https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/1997
-*
-* For some reasons, I cannot use this instead:
-*  'let iconTheme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())'
-* see https://gjs.guide/extensions/upgrading/gnome-shell-40.html#custom-icon-theme
-*  I get this error: "TypeError: Gtk.IconTheme.get_for_display is not a function"
-*  This same line of code works on prefs.js... (Gnome 43)
-*/
-Gtk.IconTheme.get_default = function () {
-    let theme = new Gtk.IconTheme();
-    // gnome-shell switched away from GTK3 during the `44.rc` release. The Gtk.IconTheme method `set_custom_name`
-    // has been renamed to `set_theme_name`. The below line allows support for all versions of GNOME 43 and 44+.
-    if (theme.set_theme_name) {
-        theme.set_theme_name(St.Settings.get().gtk_icon_theme);
-    } else {
-        theme.set_custom_theme(St.Settings.get().gtk_icon_theme);
-    }
-    return theme;
-};
 
 const CaffeineToggle = GObject.registerClass(
 class CaffeineToggle extends QuickSettings.QuickMenuToggle {
@@ -164,7 +143,8 @@ class CaffeineToggle extends QuickSettings.QuickMenuToggle {
 
         // Icons
         this.finalTimerMenuIcon = TimerMenuIcon;
-        if (!Gtk.IconTheme.get_default().has_icon(TimerMenuIcon)) {
+        let iconTheme = new St.IconTheme();
+        if (!iconTheme.has_icon(TimerMenuIcon)) {
             this.finalTimerMenuIcon =
                 Gio.icon_new_for_string(`${this._path}/icons/${TimerMenuIcon}.svg`);
         }

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -1144,13 +1144,6 @@ class Caffeine extends QuickSettings.SystemIndicator {
 });
 
 /**
- * Steps to run on initialization of the extension
- */
-function init() {
-    ExtensionUtils.initTranslations();
-}
-
-/**
  * Steps to run when the extension is enabled
  */
 function enable() {

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -382,13 +382,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
         this.lastIndicatorPosition = this.indicatorPosition;
 
         QuickSettingsMenu._indicators.insert_child_at_index(this, this.indicatorIndex);
-        QuickSettingsMenu._addItems(this.quickSettingsItems);
-
-        // Place the toggle above the background apps entry
-        this.quickSettingsItems.forEach((item) => {
-            QuickSettingsMenu.menu._grid.set_child_below_sibling(item,
-                QuickSettingsMenu._backgroundApps.quickSettingsItems[0]);
-        });
+        QuickSettingsMenu.addExternalIndicator(this.quickSettingsItems);
 
         this._updateLastIndicatorPosition();
     }

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -19,12 +19,22 @@
 
 'use strict';
 
-const { Gtk, Gio, GObject, Shell, St, Meta, Clutter, GLib } = imports.gi;
-const Config = imports.misc.config;
-const Main = imports.ui.main;
-const PopupMenu = imports.ui.popupMenu;
-const QuickSettings = imports.ui.quickSettings;
-const QuickSettingsMenu = imports.ui.main.panel.statusArea.quickSettings;
+import Gtk from 'gi://Gtk';
+import Gio from 'gi://Gio';
+import GObject from 'gi://GObject';
+import Shell from 'gi://Shell';
+import St from 'gi://St';
+import Meta from 'gi://Meta';
+import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
+
+import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+import * as QuickSettings from 'resource:///org/gnome/shell/ui/quickSettings.js';
+const QuickSettingsMenu = Main.panel.statusArea.quickSettings;
 
 const ShellVersion = Number(Config.PACKAGE_VERSION.split('.')[0]);
 
@@ -45,12 +55,6 @@ const TRIGGER_APPS_MODE = 'trigger-apps-mode';
 const INDICATOR_POSITION = 'indicator-position';
 const INDICATOR_INDEX = 'indicator-position-index';
 const INDICATOR_POS_MAX = 'indicator-position-max';
-
-const Gettext = imports.gettext.domain('gnome-shell-extension-caffeine');
-const _ = Gettext.gettext;
-
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
 
 const ColorInterface = '<node> \
   <interface name="org.gnome.SettingsDaemon.Color"> \

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -1116,10 +1116,10 @@ export default class CaffeineExtension extends Extension {
 
         // Register shortcut
         Main.wm.addKeybinding(TOGGLE_SHORTCUT, this._settings,
-                              Meta.KeyBindingFlags.IGNORE_AUTOREPEAT,
-                              Shell.ActionMode.ALL, () => {
-            this._caffeineIndicator.toggleState();
-        });
+            Meta.KeyBindingFlags.IGNORE_AUTOREPEAT,
+            Shell.ActionMode.ALL, () => {
+                this._caffeineIndicator.toggleState();
+            });
     }
 
     disable() {

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -28,7 +28,7 @@ import Meta from 'gi://Meta';
 import Clutter from 'gi://Clutter';
 import GLib from 'gi://GLib';
 
-import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
+import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Config from 'resource:///org/gnome/shell/misc/config.js';

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -19,7 +19,6 @@
 
 'use strict';
 
-import Gtk from 'gi://Gtk';
 import Gio from 'gi://Gio';
 import GObject from 'gi://GObject';
 import Shell from 'gi://Shell';
@@ -31,7 +30,6 @@ import GLib from 'gi://GLib';
 import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 import * as QuickSettings from 'resource:///org/gnome/shell/ui/quickSettings.js';
 const QuickSettingsMenu = Main.panel.statusArea.quickSettings;

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -36,8 +36,6 @@ import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 import * as QuickSettings from 'resource:///org/gnome/shell/ui/quickSettings.js';
 const QuickSettingsMenu = Main.panel.statusArea.quickSettings;
 
-const ShellVersion = Number(Config.PACKAGE_VERSION.split('.')[0]);
-
 const INHIBIT_APPS_KEY = 'inhibit-apps';
 const SHOW_INDICATOR_KEY = 'show-indicator';
 const SHOW_NOTIFICATIONS_KEY = 'show-notifications';
@@ -157,10 +155,7 @@ const CaffeineToggle = GObject.registerClass(
 class CaffeineToggle extends QuickSettings.QuickMenuToggle {
     _init(settings, path) {
         super._init({
-            // The 'label' property was renamed to 'title' in GNOME 44 but quick settings have otherwise
-            // not been changed. The below line allows support for both GNOME 43 and 44+ by using the
-            // appropriate property name based on the GNOME version.
-            [ShellVersion >= 44 ? 'title' : 'label']: _('Caffeine'),
+            'title': _('Caffeine'),
             toggleMode: true
         });
 
@@ -414,12 +409,10 @@ class Caffeine extends QuickSettings.SystemIndicator {
         QuickSettingsMenu._addItems(this.quickSettingsItems);
 
         // Place the toggle above the background apps entry
-        if (ShellVersion >= 44) {
-            this.quickSettingsItems.forEach((item) => {
-                QuickSettingsMenu.menu._grid.set_child_below_sibling(item,
-                    QuickSettingsMenu._backgroundApps.quickSettingsItems[0]);
-            });
-        }
+        this.quickSettingsItems.forEach((item) => {
+            QuickSettingsMenu.menu._grid.set_child_below_sibling(item,
+                QuickSettingsMenu._backgroundApps.quickSettingsItems[0]);
+        });
 
         this._updateLastIndicatorPosition();
     }
@@ -635,9 +628,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
     _updateLabelTimer(text) {
         this._timerLabel.text = text;
         this._caffeineToggle.menu.setHeader(this._caffeineToggle.finalTimerMenuIcon, _('Caffeine Timer'), text);
-        if (ShellVersion >= 44) {
-            this._caffeineToggle.subtitle = text;
-        }
+        this._caffeineToggle.subtitle = text;
     }
 
     _handleScrollEvent(event) {
@@ -799,23 +790,21 @@ class Caffeine extends QuickSettings.SystemIndicator {
         }
     }
 
-    // Add the name of App as subtitle (>= Gnome 44)
+    // Add the name of App as subtitle
     _updateAppSubtitle(id) {
-        if (ShellVersion >= 44) {
-            const listAppId = this._appInhibitedData.keys();
-            let appId = id !== null ? id : listAppId.next().value;
-            if (appId !== undefined) {
-                let appInfo = Gio.DesktopAppInfo.new(appId);
-                this._caffeineToggle.subtitle = appInfo !== null
-                    ? appInfo.get_display_name()
-                    : null;
-            }
+        const listAppId = this._appInhibitedData.keys();
+        let appId = id !== null ? id : listAppId.next().value;
+        if (appId !== undefined) {
+            let appInfo = Gio.DesktopAppInfo.new(appId);
+            this._caffeineToggle.subtitle = appInfo !== null
+                ? appInfo.get_display_name()
+                : null;
         }
     }
 
-    // Add the timer duration selected as subtitle (>= Gnome 44)
+    // Add the timer duration selected as subtitle
     _updateTimerSubtitle() {
-        if (ShellVersion >= 44 && !this._settings.get_boolean(TOGGLE_STATE_KEY)) {
+        if (!this._settings.get_boolean(TOGGLE_STATE_KEY)) {
             const timerDuration = this._settings.get_int(TIMER_KEY);
             this._caffeineToggle.subtitle = timerDuration !== 0
                 ? parseInt(timerDuration) + _(' minutes')

--- a/caffeine@patapon.info/metadata.json
+++ b/caffeine@patapon.info/metadata.json
@@ -1,8 +1,7 @@
 {
   "version": 48,
   "shell-version": [
-    "43",
-    "44"
+    "45"
   ],
   "uuid": "caffeine@patapon.info",
   "name": "Caffeine",

--- a/caffeine@patapon.info/preferences/appsPage.js
+++ b/caffeine@patapon.info/preferences/appsPage.js
@@ -24,7 +24,7 @@ import Gtk from 'gi://Gtk';
 import GObject from 'gi://GObject';
 import Gio from 'gi://Gio';
 
-import {gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import { gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 export var AppsPage = GObject.registerClass(
 class CaffeineAppsPage extends Adw.PreferencesPage {

--- a/caffeine@patapon.info/preferences/appsPage.js
+++ b/caffeine@patapon.info/preferences/appsPage.js
@@ -26,7 +26,7 @@ import Gio from 'gi://Gio';
 
 import {gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-var AppsPage = GObject.registerClass(
+export var AppsPage = GObject.registerClass(
 class CaffeineAppsPage extends Adw.PreferencesPage {
     _init(settings, settingsKey) {
         super._init({

--- a/caffeine@patapon.info/preferences/appsPage.js
+++ b/caffeine@patapon.info/preferences/appsPage.js
@@ -19,12 +19,12 @@
 /* exported AppsPage */
 'use strict';
 
-const { Adw, Gtk, GObject, Gio } = imports.gi;
+import Adw from 'gi://Adw';
+import Gtk from 'gi://Gtk';
+import GObject from 'gi://GObject';
+import Gio from 'gi://Gio';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
-const _ = Gettext.gettext;
+import {gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 var AppsPage = GObject.registerClass(
 class CaffeineAppsPage extends Adw.PreferencesPage {

--- a/caffeine@patapon.info/preferences/appsPage.js
+++ b/caffeine@patapon.info/preferences/appsPage.js
@@ -164,7 +164,7 @@ class CaffeineAppsPage extends Adw.PreferencesPage {
     }
 
     _onAddApp() {
-        const dialog = new NewAppDialog(this.get_root(), this._settingsKey);
+        const dialog = new NewAppDialog(this.get_root(), this._settings, this._settingsKey);
         dialog.connect('response', (dlg, id) => {
             const appInfo = id === Gtk.ResponseType.OK
                 ? dialog.get_widget().get_app_info() : null;
@@ -192,13 +192,13 @@ class CaffeineAppsPage extends Adw.PreferencesPage {
 
 const NewAppDialog = GObject.registerClass(
     class NewAppDialog extends Gtk.AppChooserDialog {
-        _init(parent, settingsKey) {
+        _init(parent, settings, settingsKey) {
             super._init({
                 transient_for: parent,
                 modal: true
             });
 
-            this._settings = ExtensionUtils.getSettings();
+            this._settings = settings;
             this._settingsKey = settingsKey;
 
             this.get_widget().set({

--- a/caffeine@patapon.info/preferences/displayPage.js
+++ b/caffeine@patapon.info/preferences/displayPage.js
@@ -26,7 +26,7 @@ import Gio from 'gi://Gio';
 
 import {gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-var DisplayPage = GObject.registerClass(
+export var DisplayPage = GObject.registerClass(
 class CaffeineDisplayPage extends Adw.PreferencesPage {
     _init(settings, settingsKey) {
         super._init({

--- a/caffeine@patapon.info/preferences/displayPage.js
+++ b/caffeine@patapon.info/preferences/displayPage.js
@@ -24,7 +24,7 @@ import Gtk from 'gi://Gtk';
 import GObject from 'gi://GObject';
 import Gio from 'gi://Gio';
 
-import {gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import { gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 export var DisplayPage = GObject.registerClass(
 class CaffeineDisplayPage extends Adw.PreferencesPage {

--- a/caffeine@patapon.info/preferences/displayPage.js
+++ b/caffeine@patapon.info/preferences/displayPage.js
@@ -19,12 +19,12 @@
 /* exported DisplayPage */
 'use strict';
 
-const { Adw, Gtk, GObject, Gio } = imports.gi;
+import Adw from 'gi://Adw';
+import Gtk from 'gi://Gtk';
+import GObject from 'gi://GObject';
+import Gio from 'gi://Gio';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
-const _ = Gettext.gettext;
+import {gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 var DisplayPage = GObject.registerClass(
 class CaffeineDisplayPage extends Adw.PreferencesPage {

--- a/caffeine@patapon.info/preferences/generalPage.js
+++ b/caffeine@patapon.info/preferences/generalPage.js
@@ -19,12 +19,13 @@
 /* exported GeneralPage */
 'use strict';
 
-const { Adw, Gtk, GObject, Gdk } = imports.gi;
+import Adw from 'gi://Adw';
+import Gtk from 'gi://Gtk';
+import GObject from 'gi://GObject';
+import Gdk from 'gi://Gdk';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
-const _ = Gettext.gettext;
+import {gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+
 const genParam = (type, name, ...dflt) => GObject.ParamSpec[type](name, name, name, GObject.ParamFlags.READWRITE, ...dflt);
 
 const TIMERS_DURATION = [

--- a/caffeine@patapon.info/preferences/generalPage.js
+++ b/caffeine@patapon.info/preferences/generalPage.js
@@ -36,7 +36,7 @@ const TIMERS_DURATION = [
     '30, 50, 80'
 ];
 
-var GeneralPage = GObject.registerClass(
+export var GeneralPage = GObject.registerClass(
 class CaffeineGeneralPage extends Adw.PreferencesPage {
     _init(settings, settingsKey) {
         super._init({

--- a/caffeine@patapon.info/preferences/generalPage.js
+++ b/caffeine@patapon.info/preferences/generalPage.js
@@ -24,7 +24,7 @@ import Gtk from 'gi://Gtk';
 import GObject from 'gi://GObject';
 import Gdk from 'gi://Gdk';
 
-import {gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import { gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 const genParam = (type, name, ...dflt) => GObject.ParamSpec[type](name, name, name, GObject.ParamFlags.READWRITE, ...dflt);
 

--- a/caffeine@patapon.info/prefs.js
+++ b/caffeine@patapon.info/prefs.js
@@ -19,14 +19,14 @@
 /* exported init fillPreferencesWindow */
 'use strict';
 
-const { Gtk, Gdk } = imports.gi;
+//Main imports
+import Gtk from 'gi://Gtk';
+import Gdk from 'gi://Gdk';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
 // Import preferences pages
-const GeneralPrefs = Me.imports.preferences.generalPage;
-const DisplayPrefs = Me.imports.preferences.displayPage;
-const AppsPrefs = Me.imports.preferences.appsPage;
+import * as GeneralPrefs from './preferences/generalPage.js';
+import * as DisplayPrefs from './preferences/displayPage.js';
+import * as AppsPrefs from './preferences/appsPage.js';
 
 const SettingsKey = {
     INHIBIT_APPS: 'inhibit-apps',

--- a/caffeine@patapon.info/prefs.js
+++ b/caffeine@patapon.info/prefs.js
@@ -16,7 +16,7 @@
 
    // From https://gitlab.com/skrewball/openweather/-/blob/master/src/prefs.js
 */
-/* exported fillPreferencesWindow */
+/* exported CaffeinePrefs */
 'use strict';
 
 //Main imports
@@ -27,6 +27,8 @@ import Gdk from 'gi://Gdk';
 import * as GeneralPrefs from './preferences/generalPage.js';
 import * as DisplayPrefs from './preferences/displayPage.js';
 import * as AppsPrefs from './preferences/appsPage.js';
+
+import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 const SettingsKey = {
     INHIBIT_APPS: 'inhibit-apps',
@@ -47,35 +49,37 @@ const SettingsKey = {
     INDICATOR_POS_MAX: 'indicator-position-max'
 };
 
-function fillPreferencesWindow(window) {
-    let iconTheme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default());
-    if (!iconTheme.get_search_path().includes(Me.path + '/icons')) {
-        iconTheme.add_search_path(Me.path + '/icons');
-    }
-
-    const settings = ExtensionUtils.getSettings();
-    const generalPage = new GeneralPrefs.GeneralPage(settings, SettingsKey);
-    const displayPage = new DisplayPrefs.DisplayPage(settings, SettingsKey);
-    const appsPage = new AppsPrefs.AppsPage(settings, SettingsKey);
-
-    let prefsWidth = settings.get_int(SettingsKey.DEFAULT_WIDTH);
-    let prefsHeight = settings.get_int(SettingsKey.DEFAULT_HEIGHT);
-
-    window.set_default_size(prefsWidth, prefsHeight);
-    window.set_search_enabled(true);
-
-    window.add(generalPage);
-    window.add(displayPage);
-    window.add(appsPage);
-
-    window.connect('close-request', () => {
-        let currentWidth = window.default_width;
-        let currentHeight = window.default_height;
-        // Remember user window size adjustments.
-        if (currentWidth !== prefsWidth || currentHeight !== prefsHeight) {
-            settings.set_int(SettingsKey.DEFAULT_WIDTH, currentWidth);
-            settings.set_int(SettingsKey.DEFAULT_HEIGHT, currentHeight);
+export default class CaffeinePrefs extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        let iconTheme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default());
+        if (!iconTheme.get_search_path().includes(this.path + '/icons')) {
+            iconTheme.add_search_path(this.path + '/icons');
         }
-        window.destroy();
-    });
+
+        const settings = this.getSettings();
+        const generalPage = new GeneralPrefs.GeneralPage(settings, SettingsKey);
+        const displayPage = new DisplayPrefs.DisplayPage(settings, SettingsKey);
+        const appsPage = new AppsPrefs.AppsPage(settings, SettingsKey);
+
+        let prefsWidth = settings.get_int(SettingsKey.DEFAULT_WIDTH);
+        let prefsHeight = settings.get_int(SettingsKey.DEFAULT_HEIGHT);
+
+        window.set_default_size(prefsWidth, prefsHeight);
+        window.set_search_enabled(true);
+
+        window.add(generalPage);
+        window.add(displayPage);
+        window.add(appsPage);
+
+        window.connect('close-request', () => {
+            let currentWidth = window.default_width;
+            let currentHeight = window.default_height;
+            // Remember user window size adjustments.
+            if (currentWidth !== prefsWidth || currentHeight !== prefsHeight) {
+                settings.set_int(SettingsKey.DEFAULT_WIDTH, currentWidth);
+                settings.set_int(SettingsKey.DEFAULT_HEIGHT, currentHeight);
+            }
+            window.destroy();
+        });
+    }
 }

--- a/caffeine@patapon.info/prefs.js
+++ b/caffeine@patapon.info/prefs.js
@@ -28,7 +28,7 @@ import * as GeneralPrefs from './preferences/generalPage.js';
 import * as DisplayPrefs from './preferences/displayPage.js';
 import * as AppsPrefs from './preferences/appsPage.js';
 
-import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 const SettingsKey = {
     INHIBIT_APPS: 'inhibit-apps',

--- a/caffeine@patapon.info/prefs.js
+++ b/caffeine@patapon.info/prefs.js
@@ -19,7 +19,6 @@
 /* exported CaffeinePrefs */
 'use strict';
 
-//Main imports
 import Gtk from 'gi://Gtk';
 import Gdk from 'gi://Gdk';
 

--- a/caffeine@patapon.info/prefs.js
+++ b/caffeine@patapon.info/prefs.js
@@ -16,7 +16,7 @@
 
    // From https://gitlab.com/skrewball/openweather/-/blob/master/src/prefs.js
 */
-/* exported init fillPreferencesWindow */
+/* exported fillPreferencesWindow */
 'use strict';
 
 //Main imports
@@ -46,10 +46,6 @@ const SettingsKey = {
     INDICATOR_INDEX: 'indicator-position-index',
     INDICATOR_POS_MAX: 'indicator-position-max'
 };
-
-function init() {
-    ExtensionUtils.initTranslations(Me.metadata['gettext-domain']);
-}
 
 function fillPreferencesWindow(window) {
     let iconTheme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default());


### PR DESCRIPTION
This ports the extension to GNOME 45, pretty self-explanatory

I've tested the extension where I can, it seems to all work, translations included (using Fedora Rawhide, with GNOME 45 Beta).

Issues:
 - Extension crashes if brought enabled when logging in
   - `_backgroundApps` is made asynchronously and suffers a race-condition
   - Upstream is working on a fix, I'll use the new method when it's ready upstream

This also changes the README with some new versions:
 - Before merging this, we need to update the version to `49`, make a release and then branch off GNOME 43 / 44
 - After merging this (it'll need a rebase), update the version to `50` and make another release.
That way, GNOME 43 / 44 get to benefit from the recent translation and bug fix work.

This doesn't make use of libadwaita 1.4, but the only interesting this from that is a shorter way to add a switch to the preference row. Someone with more experience of libadwaita is free to do that :)

After the background apps fix is done, I'm happy with this PR, and I'll mark it ready for merging / further review.

Closes #289