### PR TITLE
Add missing metadata extension name

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -1106,13 +1106,6 @@ class Caffeine extends QuickSettings.SystemIndicator {
 });
 
 export default class CaffeineExtension extends Extension {
-    /**
-     * @param {ExtensionMeta} metadata - Caffeine extension metadata
-     */
-    constructor(metadata) {
-        super(metadata);
-    }
-
     enable() {
         this._settings = this.getSettings();
         this._caffeineIndicator = new Caffeine(this._settings, this.path, this.metadata.name);

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -1106,9 +1106,16 @@ class Caffeine extends QuickSettings.SystemIndicator {
 });
 
 export default class CaffeineExtension extends Extension {
+    /**
+     * @param {ExtensionMeta} metadata - Caffeine extension metadata
+     */
+    constructor(metadata) {
+        super(metadata);
+    }
+
     enable() {
         this._settings = this.getSettings();
-        this._caffeineIndicator = new Caffeine(this._settings, this.path);
+        this._caffeineIndicator = new Caffeine(this._settings, this.path, this.metadata.name);
 
         // Register shortcut
         Main.wm.addKeybinding(TOGGLE_SHORTCUT, this._settings,


### PR DESCRIPTION
This is a small fix for the missing extension name when creating **Caffeine**. It was resulting in bad inhibitor description: `Inhibit by undefined` instead of `Inhibit by Caffeine`. It take the name extension from the metadata file.