### PR TITLE
Sync number version with release - v52 - Gnome 45

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This extension supports GNOME Shell `3.4` -> `45`
 
 |Branch                   |Version|Compatible GNOME version|
 |-------------------------|:-----:|------------------------|
-| master                  |    50 | GNOME 45               |
-| gnome-shell-43-44       |    49 | GNOME 43 -> 44         |
+| master                  |    52 | GNOME 45               |
+| gnome-shell-43-44       |    51 | GNOME 43 -> 44         |
 | gnome-shell-40-42       |    42 | GNOME 40 -> 42         |
 | gnome-shell-3.36-3.38   |    37 | GNOME 3.36 -> 3.38     |
 | gnome-shell-3.32-3.34   |    33 | GNOME 3.32 -> 3.34     |

--- a/caffeine@patapon.info/metadata.json
+++ b/caffeine@patapon.info/metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": 50,
+  "version": 52,
   "shell-version": [
     "45"
   ],


### PR DESCRIPTION
There is a gap between the version number present in Github and the release one : this can be a bit confusing. 
This fix will update the version to the current release v52 (master branch).