### PR TITLE
Sync number version with release - v51 - Gnome 44

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This extension supports GNOME Shell `3.4` -> `44`
 
 |Branch                   |Version|Compatible Gnome version|
 |-------------------------|:-----:|------------------------|
-| master                  |    46 | Gnome 43 -> 44         |
+| master                  |    51 | Gnome 43 -> 44         |
 | gnome-shell-40-42       |    42 | Gnome 40 -> 42         |
 | gnome-shell-3.36-3.38   |    37 | Gnome 3.36 -> 3.38     |
 | gnome-shell-3.32-3.34   |    33 | Gnome 3.32 -> 3.34     |

--- a/caffeine@patapon.info/metadata.json
+++ b/caffeine@patapon.info/metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": 49,
+  "version": 51,
   "shell-version": [
     "43",
     "44"


### PR DESCRIPTION
There is a gap between the version number present in Github and the release one : this can be a bit confusing. 
This fix will update the version to the last Gnome 44 release v51 (gnome-shell-43-44 branch).