### PR TITLE
Fix adw_action_row_add_suffix assertion failure

### DIFF
--- a/caffeine@patapon.info/preferences/generalPage.js
+++ b/caffeine@patapon.info/preferences/generalPage.js
@@ -255,7 +255,6 @@ const ShortcutSettingWidget = class extends Adw.ActionRow {
         this._settings = settings;
         this._description = sublabel;
 
-        this.add_suffix(this.shortcutBox);
         this.shortLabel = new Gtk.ShortcutLabel({
             disabled_text: _('New accelerator…'),
             valign: Gtk.Align.CENTER,


### PR DESCRIPTION
`add_suffix()` was being called twice. The first time it gave the element a parent, and the second time the assertion fails because the element already has a parent.

Log:
```
gjs[57017]: adw_action_row_add_suffix: assertion 'gtk_widget_get_parent (widget) == NULL' failed
```