### PR TITLE
Port Adw.ActionRow and switch to Adw.SwitchRow

### DIFF
--- a/caffeine@patapon.info/preferences/displayPage.js
+++ b/caffeine@patapon.info/preferences/displayPage.js
@@ -94,6 +94,7 @@ class CaffeineDisplayPage extends Adw.PreferencesPage {
         // Bind signals
         // --------------
         showStatusIndicatorRow.connect('notify::selected', (widget) => {
+            // Grey out show timer setting if the indicator is set to never show
             if (widget.selected === 2) {
                 showTimerRow.set_sensitive(false);
             } else {

--- a/caffeine@patapon.info/preferences/displayPage.js
+++ b/caffeine@patapon.info/preferences/displayPage.js
@@ -56,28 +56,18 @@ class CaffeineDisplayPage extends Adw.PreferencesPage {
         });
 
         // Show timer
-        let showTimerSwitch = new Gtk.Switch({
-            valign: Gtk.Align.CENTER,
-            active: this._settings.get_boolean(this._settingsKey.SHOW_TIMER)
-        });
-        let showTimerRow = new Adw.ActionRow({
+        let showTimerRow = new Adw.SwitchRow({
             title: _('Show timer in top panel'),
             subtitle: _('Enable or disable the timer in the top panel'),
-            activatable_widget: showTimerSwitch
+            active: this._settings.get_boolean(this._settingsKey.SHOW_TIMER)
         });
-        showTimerRow.add_suffix(showTimerSwitch);
 
         // Notifications
-        let notificationSwitch = new Gtk.Switch({
-            valign: Gtk.Align.CENTER,
-            active: this._settings.get_boolean(this._settingsKey.SHOW_NOTIFICATIONS)
-        });
-        let notificationRow = new Adw.ActionRow({
+        let notificationRow = new Adw.SwitchRow({
             title: _('Notifications'),
             subtitle: _('Enable notifications when Caffeine is enabled or disabled'),
-            activatable_widget: notificationSwitch
+            active: this._settings.get_boolean(this._settingsKey.SHOW_NOTIFICATIONS)
         });
-        notificationRow.add_suffix(notificationSwitch);
 
         // Indicator position offset
         this.lastIndicatorPos = this._settings.get_int(this._settingsKey.INDICATOR_POS_MAX);
@@ -105,16 +95,16 @@ class CaffeineDisplayPage extends Adw.PreferencesPage {
         // --------------
         showStatusIndicatorRow.connect('notify::selected', (widget) => {
             if (widget.selected === 2) {
-                showTimerSwitch.set_sensitive(false);
+                showTimerRow.set_sensitive(false);
             } else {
-                showTimerSwitch.set_sensitive(true);
+                showTimerRow.set_sensitive(true);
             }
             this._settings.set_enum(this._settingsKey.SHOW_INDICATOR, widget.selected);
         });
-        showTimerSwitch.connect('notify::active', (widget) => {
+        showTimerRow.connect('notify::active', (widget) => {
             this._settings.set_boolean(this._settingsKey.SHOW_TIMER, widget.get_active());
         });
-        notificationSwitch.connect('notify::active', (widget) => {
+        notificationRow.connect('notify::active', (widget) => {
             this._settings.set_boolean(this._settingsKey.SHOW_NOTIFICATIONS, widget.get_active());
         });
         this._settings.bind(this._settingsKey.INDICATOR_POSITION,

--- a/caffeine@patapon.info/preferences/generalPage.js
+++ b/caffeine@patapon.info/preferences/generalPage.js
@@ -53,29 +53,19 @@ class CaffeineGeneralPage extends Adw.PreferencesPage {
             title: _('Behavior')
         });
 
-        // Enable / Disable fullscreen apps
-        let disableFullscreenSwitch = new Gtk.Switch({
-            valign: Gtk.Align.CENTER,
-            active: this._settings.get_boolean(this._settingsKey.FULLSCREEN)
-        });
-        let disableFullscreenRow = new Adw.ActionRow({
+        // Enable / disable fullscreen apps
+        let disableFullscreenRow = new Adw.SwitchRow({
             title: _('Enable for fullscreen apps'),
             subtitle: _('Automatically enable when an app enters fullscreen mode'),
-            activatable_widget: disableFullscreenSwitch
+            active: this._settings.get_boolean(this._settingsKey.FULLSCREEN)
         });
-        disableFullscreenRow.add_suffix(disableFullscreenSwitch);
 
         // Remember state
-        let rememberStateSwitch = new Gtk.Switch({
-            valign: Gtk.Align.CENTER,
-            active: this._settings.get_boolean(this._settingsKey.RESTORE)
-        });
-        let rememberStateRow = new Adw.ActionRow({
+        let rememberStateRow = new Adw.SwitchRow({
             title: _('Remember state'),
             subtitle: _('Remember the last state across sessions and reboots'),
-            activatable_widget: rememberStateSwitch
+            active: this._settings.get_boolean(this._settingsKey.RESTORE)
         });
-        rememberStateRow.add_suffix(rememberStateSwitch);
 
         // Pause and resume Night Light
         let pauseNightLight = new Gtk.StringList();
@@ -184,10 +174,10 @@ class CaffeineGeneralPage extends Adw.PreferencesPage {
 
         // Bind signals
         // --------------
-        disableFullscreenSwitch.connect('notify::active', (widget) => {
+        disableFullscreenRow.connect('notify::active', (widget) => {
             this._settings.set_boolean(this._settingsKey.FULLSCREEN, widget.get_active());
         });
-        rememberStateSwitch.connect('notify::active', (widget) => {
+        rememberStateRow.connect('notify::active', (widget) => {
             this._settings.set_boolean(this._settingsKey.RESTORE, widget.get_active());
         });
         pauseNightLightRow.connect('notify::selected', (widget) => {


### PR DESCRIPTION
Now we're using libadwaitia 1.4+ with GNOME 45+, we can port the custom rows to using libadwaita provided elements

Similar to #325