### PR TITLE
Force Eslint version 8.57.0

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,7 +16,7 @@ jobs:
         version: 1.0
     - name: Install eslint
       run: |
-        npm install -g eslint eslint-plugin-jsdoc
+        npm install -g eslint@8.57.0 eslint-plugin-jsdoc
 
     - name: Run linter target
       run: |


### PR DESCRIPTION
Eslint 9 seams to need a complete config rewrite: I tried to migrate the config file to version 9, but I'm not very familiar with it.
In the meantime, we can use the last stable version of Eslint 8 to keep process working.