### PR TITLE
Refactor extension to use an inhibitor manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,20 +60,3 @@ This option enable Caffeine for a given amount of time (similar to Caffeine in L
 ### Preferences
 
 ![Preferences](screenshots/screenshot-prefs.png)
-
-## CLI
-
-- Get current state:
-  ```sh
-  gsettings --schemadir ~/.local/share/gnome-shell/extensions/caffeine@patapon.info/schemas/ get org.gnome.shell.extensions.caffeine toggle-state
-  ```
-- Enable Caffeine:
-  ```sh
-  gsettings --schemadir ~/.local/share/gnome-shell/extensions/caffeine@patapon.info/schemas/ set org.gnome.shell.extensions.caffeine toggle-state true
-  ```
-- Disable Caffeine:
-  ```sh
-  gsettings --schemadir ~/.local/share/gnome-shell/extensions/caffeine@patapon.info/schemas/ set org.gnome.shell.extensions.caffeine toggle-state false
-  ```
-
-`--schemadir` — path to the extension schemas directory. It may be different on your system.

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -331,11 +331,14 @@ const InhibitorManager = GObject.registerClass({
                 this._isWaitingInhibit = false;
 
                 // Delete the inhibitor if we're not supposed to have it
-                if (!this._skipInhibit) {
+                /* We shouldn't need to check for this._isInhibited, but we
+                   might be able to recover from a bug if we do
+                */
+                if (this._skipInhibit || this._isInhibited) {
+                    this._removeInhibitor();
+                } else {
                     this._isInhibited = true;
                     this._inhibitorCookie = cookie;
-                } else {
-                    this._removeInhibitor();
                 }
             }
         );

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -666,6 +666,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
             this._removeTimer();
         }
 
+        this._updateTimerSubtitle();
         this._updateMaxPosition();
     }
 

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -199,8 +199,10 @@ const InhibitorManager = GObject.registerClass({
 
         for (let appId of possibleTriggerApps) {
             let app = this._appSystem.lookup_app(appId);
-            if (app.is_on_workspace(activeWorkspace)) {
-                return appId;
+            if (app !== null) {
+                if (app.is_on_workspace(activeWorkspace)) {
+                    return appId;
+                }
             }
         }
 

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -129,6 +129,7 @@ const InhibitorManager = GObject.registerClass({
         this._appStateSignal = null;
         this._focusWindowSignal = null;
         this._workspaceSignal = null;
+        this._restackedSignal = null;
 
         // DBus proxies
         this._sessionManager = new DBusSessionManagerProxy(Gio.DBus.session,
@@ -190,6 +191,8 @@ const InhibitorManager = GObject.registerClass({
                 () => this._updateState());
             this._workspaceSignal = global.workspace_manager.connect('workspace-switched',
                 () => this._updateState());
+            this._restackedSignal = global.display.connect('restacked',
+                () => this._updateState());
             break;
         }
     }
@@ -204,8 +207,12 @@ const InhibitorManager = GObject.registerClass({
             this._focusWindowSignal = null;
         }
         if (this._workspaceSignal !== null) {
-            global.workspace_manager.disconnect();
+            global.workspace_manager.disconnect(this._workspaceSignal);
             this._workspaceSignal = null;
+        }
+        if (this._restackedSignal !== null) {
+            global.display.disconnect(this._restackedSignal);
+            this._restackedSignal = null;
         }
     }
 

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -574,7 +574,6 @@ class Caffeine extends QuickSettings.SystemIndicator {
         this._timeOut = null;
         this._timePrint = null;
         this._timerEnable = false;
-        this._timeAppUnblock = null;
 
         // Show icon
         this._manageShowIndicator();
@@ -938,10 +937,6 @@ class Caffeine extends QuickSettings.SystemIndicator {
         if (this._timePrint) {
             GLib.Source.remove(this._timePrint);
             this._timePrint = null;
-        }
-        if (this._timeAppUnblock) {
-            GLib.Source.remove(this._timeAppUnblock);
-            this._timeAppUnblock = null;
         }
 
         this._inhibitorManager.destroy();

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -324,24 +324,26 @@ const InhibitorManager = GObject.registerClass({
         }
 
         // Add an inhibitor and save the cookie
-        this._isWaitingInhibit = true;
-        this._sessionManager.InhibitRemote('caffeine-gnome-extension', 0,
-            'Inhibit by %s'.format(this._name), inhibitFlags,
-            (cookie) => {
-                this._isWaitingInhibit = false;
+        if (!this._isWaitingInhibit) {
+            this._isWaitingInhibit = true;
+            this._sessionManager.InhibitRemote('caffeine-gnome-extension', 0,
+                'Inhibit by %s'.format(this._name), inhibitFlags,
+                (cookie) => {
+                    this._isWaitingInhibit = false;
 
-                // Delete the inhibitor if we're not supposed to have it
-                /* We shouldn't need to check for this._isInhibited, but we
-                   might be able to recover from a bug if we do
-                */
-                if (this._skipInhibit || this._isInhibited) {
-                    this._removeInhibitor();
-                } else {
-                    this._isInhibited = true;
-                    this._inhibitorCookie = cookie;
+                    // Delete the inhibitor if we're not supposed to have it
+                    /* We shouldn't need to check for this._isInhibited, but we
+                       might be able to recover from a bug if we do
+                    */
+                    if (this._skipInhibit || this._isInhibited) {
+                        this._removeInhibitor();
+                    } else {
+                        this._isInhibited = true;
+                        this._inhibitorCookie = cookie;
+                    }
                 }
-            }
-        );
+            );
+        }
     }
 
     _removeInhibitor() {

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -41,7 +41,6 @@ const SHOW_INDICATOR_KEY = 'show-indicator';
 const SHOW_NOTIFICATIONS_KEY = 'show-notifications';
 const SHOW_TIMER_KEY = 'show-timer';
 const DURATION_TIMER_LIST = 'duration-timer-list';
-const TOGGLE_STATE_KEY = 'toggle-state';
 const USER_ENABLED_KEY = 'user-enabled';
 const RESTORE_KEY = 'restore-state';
 const FULLSCREEN_KEY = 'enable-fullscreen';
@@ -75,29 +74,10 @@ const DBusSessionManagerIface = '<node>\
     <method name="Uninhibit">\
         <arg type="u" direction="in" />\
     </method>\
-       <method name="GetInhibitors">\
-           <arg type="ao" direction="out" />\
-       </method>\
-    <signal name="InhibitorAdded">\
-        <arg type="o" direction="out" />\
-    </signal>\
-    <signal name="InhibitorRemoved">\
-        <arg type="o" direction="out" />\
-    </signal>\
   </interface>\
 </node>';
 
 const DBusSessionManagerProxy = Gio.DBusProxy.makeProxyWrapper(DBusSessionManagerIface);
-
-const DBusSessionManagerInhibitorIface = '<node>\
-  <interface name="org.gnome.SessionManager.Inhibitor">\
-    <method name="GetAppId">\
-        <arg type="s" direction="out" />\
-    </method>\
-  </interface>\
-</node>';
-
-const DBusSessionManagerInhibitorProxy = Gio.DBusProxy.makeProxyWrapper(DBusSessionManagerInhibitorIface);
 
 const ActionsPath = '/icons/hicolor/scalable/actions/';
 const DisabledIcon = 'my-caffeine-off-symbolic';
@@ -128,12 +108,286 @@ const AppsTrigger = {
     ON_ACTIVE_WORKSPACE: 2
 };
 
-const CaffeineToggle = GObject.registerClass(
-class CaffeineToggle extends QuickSettings.QuickMenuToggle {
+const InhibitorManager = GObject.registerClass({
+    Signals: {
+        'update': {}
+    }
+}, class InhibitorManager extends GObject.Object {
+    _init(settings) {
+        super._init();
+
+        this._isInhibited = false;
+        this._inhibitorCookie = null;
+        this._userEnabled = false;
+        this._triggerApp = null;
+        this._previousReasons = [];
+
+        // DBus proxies
+        this._sessionManager = new DBusSessionManagerProxy(Gio.DBus.session,
+            'org.gnome.SessionManager',
+            '/org/gnome/SessionManager');
+        this._colorProxy = new ColorProxy(
+            Gio.DBus.session,
+            'org.gnome.SettingsDaemon.Color',
+            '/org/gnome/SettingsDaemon/Color',
+            (proxy, error) => {
+                if (error) {
+                    log(error.message);
+                }
+            }
+        );
+
+        this._settings = settings;
+        this._appSystem = Shell.AppSystem.get_default();
+        this._lastNightLightDisabled = this._colorProxy.DisabledUntilTomorrow;
+
+        // Update state when extension settings changed
+        this._settings.connectObject(
+            `changed::${SCREEN_BLANK}`,
+            () => this._forceUpdate(),
+            `changed::${FULLSCREEN_KEY}`,
+            () => this._updateState(),
+            `changed::${NIGHT_LIGHT_KEY}`,
+            () => this._updateState(),
+            `changed::${INHIBIT_APPS_KEY}`,
+            () => this._updateState(),
+            `changed::${TRIGGER_APPS_MODE}`,
+            () => this._updateState(), this);
+
+        // Update state when fullscreened
+        global.display.connectObject('in-fullscreen-changed', () => this._updateState(), this);
+
+        // Update when possible app triggers change
+        this._appSystem.connectObject('app-state-changed', () => this._updateState(), this);
+        global.display.connectObject('notify::focus-window', () => this._updateState(), this);
+        global.workspace_manager.connectObject('workspace-switched',
+            () => this._updateState(), this);
+
+        this._updateState();
+    }
+
+    _findRunningApp() {
+        let possibleTriggerApps = this._settings.get_strv(INHIBIT_APPS_KEY);
+        let runningApps = this._appSystem.get_running();
+
+        for (let app of runningApps) {
+            let appId = app.get_id();
+            if (possibleTriggerApps.includes(appId)) {
+                return appId;
+            }
+        }
+
+        return null;
+    }
+
+    _findFocusedApp() {
+        let possibleTriggerApps = this._settings.get_strv(INHIBIT_APPS_KEY);
+        let focusedApp = Shell.WindowTracker.get_default().focus_app;
+        if (focusedApp !== null) {
+            let appId = focusedApp.get_id();
+            if (possibleTriggerApps.includes(appId)) {
+                return appId;
+            }
+        }
+
+        return null;
+    }
+
+    _findActiveApp() {
+        let possibleTriggerApps = this._settings.get_strv(INHIBIT_APPS_KEY);
+        let activeWorkspace = global.workspace_manager.get_active_workspace();
+
+        for (let appId of possibleTriggerApps) {
+            let app = this._appSystem.lookup_app(appId);
+            if (app.is_on_workspace(activeWorkspace)) {
+                return appId;
+            }
+        }
+
+        return null;
+    }
+
+    _getInhibitReasons() {
+        let reasons = [];
+        if (this.isFullscreen() && this._settings.get_boolean(FULLSCREEN_KEY)) {
+            reasons.push('fullscreen');
+        }
+
+        if (this._userEnabled) {
+            reasons.push('user');
+        }
+
+        // Find any selected apps that meet the trigger
+        let triggerApp = null;
+        if (this._settings.get_strv(INHIBIT_APPS_KEY).length !== 0) {
+            switch (this._settings.get_enum(TRIGGER_APPS_MODE)) {
+            case AppsTrigger.ON_RUNNING:
+                triggerApp = this._findRunningApp();
+                break;
+            case AppsTrigger.ON_FOCUS:
+                triggerApp = this._findFocusedApp();
+                break;
+            case AppsTrigger.ON_ACTIVE_WORKSPACE:
+                triggerApp = this._findActiveApp();
+                break;
+            }
+        }
+
+        // Save any responsible app and update reasons
+        this._triggerApp = triggerApp;
+        if (triggerApp !== null) {
+            reasons.push('app');
+        }
+
+        return reasons;
+    }
+
+    _forceUpdate() {
+        // Remove any inhibitor, as settings / inhibit flags may have changed
+        if (this._isInhibited) {
+            this._removeInhibitor();
+        }
+
+        // Update state, as normal
+        this._updateState();
+    }
+
+    _updateState() {
+        // Get the reasons for inhibiting
+        let reasons = this._getInhibitReasons();
+        let shouldInhibit = reasons.length !== 0;
+
+        // If previous reasons includes the user's choice and now it doesn't force disable
+        let forceDisable = false;
+        if (this._previousReasons.includes('user') && !reasons.includes('user')) {
+            forceDisable = true;
+        }
+        this._previousReasons = reasons;
+
+        // Update inhibitor and night light if required
+        let newState = shouldInhibit && !forceDisable;
+        let handleNightLight = this.isNightLightManaged();
+        if (this._isInhibited !== newState) {
+            if (newState) {
+                this._addInhibitor(reasons);
+
+                if (handleNightLight) {
+                    // Turn night light on
+                    this._colorProxy.DisabledUntilTomorrow = false;
+                    this._lastNightLightDisabled = false;
+                }
+            } else {
+                this._removeInhibitor();
+
+                if (handleNightLight) {
+                    // Turn night light off
+                    this._colorProxy.DisabledUntilTomorrow = true;
+                    this._lastNightLightDisabled = true;
+                }
+            }
+        }
+
+        // Let indicator know that either the state or reasons may have changed
+        this.emit('update');
+    }
+
+    _addInhibitor(reasons) {
+        // Decide whether to allow screen blanking
+        let allowBlank = this._settings.get_enum(SCREEN_BLANK) === ControlContext.ALWAYS;
+        if (reasons.includes('app')) {
+            allowBlank = this._settings.get_enum(SCREEN_BLANK) > ControlContext.NEVER;
+        }
+
+        let inhibitFlags;
+        if (allowBlank) {
+            // Inhibit suspending the session or computer
+            inhibitFlags = 4;
+        } else {
+            // Inhibit the session being marked as idle
+            inhibitFlags = 12;
+        }
+
+        // Add an inhibitor and save the cookie
+        this._sessionManager.InhibitRemote('caffeine-gnome-extension', 0,
+            'Inhibit by %s'.format(this._name), inhibitFlags,
+            (cookie) => {
+                this._inhibitorCookie = cookie;
+            }
+        );
+        this._isInhibited = true;
+    }
+
+    _removeInhibitor() {
+        // Use the cookie to remove the inhibitor
+        this._sessionManager.UninhibitRemote(this._inhibitorCookie);
+        this._inhibitorCookie = null;
+        this._isInhibited = false;
+    }
+
+    isFullscreen() {
+        let monitorCount = global.display.get_n_monitors();
+        for (let i = 0; i < monitorCount; i++) {
+            if (global.display.get_monitor_in_fullscreen(i)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    isNightLightManaged() {
+        let handleNightLight = this._settings.get_enum(NIGHT_LIGHT_KEY) === ControlContext.ALWAYS;
+        if (this._previousReasons.includes('app')) {
+            handleNightLight = this._settings.get_enum(NIGHT_LIGHT_KEY) > ControlContext.NEVER;
+        }
+
+        // Don't handle the night light if it's been changed
+        if (this._lastNightLightDisabled !== this._colorProxy.DisabledUntilTomorrow) {
+            handleNightLight = false;
+        }
+
+        return handleNightLight;
+    }
+
+    isNightLightOn() {
+        return this._colorProxy.NightLightActive;
+    }
+
+    getInhibitState() {
+        return this._isInhibited;
+    }
+
+    getInhibitApp() {
+        return this._triggerApp;
+    }
+
+    setUserEnabled(enabled) {
+        this._userEnabled = enabled;
+        this._updateState();
+    }
+
+    destroy() {
+        global.display.disconnectObject(this);
+        this._settings.disconnectObject(this);
+        this._appSystem.disconnectObject(this);
+        global.display.disconnectObject(this);
+        global.workspace_manager.disconnectObject(this);
+
+        if (this._isInhibited) {
+            this._removeInhibitor();
+        }
+    }
+});
+
+const CaffeineToggle = GObject.registerClass({
+    Signals: {
+        'timer-clicked': {}
+    }
+}, class CaffeineToggle extends QuickSettings.QuickMenuToggle {
     _init(Me) {
         super._init({
             'title': _('Caffeine'),
-            toggleMode: true
+            toggleMode: false
         });
 
         this._settings = Me._settings;
@@ -154,7 +408,7 @@ class CaffeineToggle extends QuickSettings.QuickMenuToggle {
         if (!this._iconTheme.has_icon(DisabledIcon)) {
             this._iconDeactivated = Gio.icon_new_for_string(`${this._path}${ActionsPath}${DisabledIcon}.svg`);
         }
-        this._iconName();
+        this.updateIcon();
 
         // Menu
         this.menu.setHeader(this.finalTimerMenuIcon, _('Caffeine Timer'), null);
@@ -176,12 +430,7 @@ class CaffeineToggle extends QuickSettings.QuickMenuToggle {
         this._syncTimers(false);
 
         // Bind signals
-        this._settings.bind(`${TOGGLE_STATE_KEY}`,
-            this, 'checked',
-            Gio.SettingsBindFlags.DEFAULT);
         this._settings.connectObject(
-            `changed::${TOGGLE_STATE_KEY}`,
-            () => this._iconName(),
             `changed::${TIMER_KEY}`,
             () => this._sync(),
             `changed::${DURATION_TIMER_LIST}`,
@@ -263,11 +512,11 @@ class CaffeineToggle extends QuickSettings.QuickMenuToggle {
 
     _checkTimer(timerId) {
         this._settings.set_int(TIMER_KEY, timerId);
-        this._settings.set_boolean(TOGGLE_STATE_KEY, true);
+        this.emit('timer-clicked');
     }
 
-    _iconName() {
-        if (this._settings.get_boolean(TOGGLE_STATE_KEY)) {
+    updateIcon() {
+        if (this.checked) {
             this.gicon = this._iconActivated;
         } else {
             this.gicon = this._iconDeactivated;
@@ -280,35 +529,11 @@ class Caffeine extends QuickSettings.SystemIndicator {
     _init(Me) {
         super._init();
 
+        this._appSystem = Shell.AppSystem.get_default();
         this._indicator = this._addIndicator();
         this._settings = Me._settings;
         this._name = Me.metadata.name;
-
-        // D-bus
-        this._proxy = new ColorProxy(
-            Gio.DBus.session,
-            'org.gnome.SettingsDaemon.Color',
-            '/org/gnome/SettingsDaemon/Color',
-            (proxy, error) => {
-                if (error) {
-                    log(error.message);
-                }
-            }
-        );
-        this._sessionManager = new DBusSessionManagerProxy(Gio.DBus.session,
-            'org.gnome.SessionManager',
-            '/org/gnome/SessionManager');
-
-        // From auto-move-windows@gnome-shell-extensions.gcampax.github.com
-        this._appSystem = Shell.AppSystem.get_default();
-        this._activeWorkspace = null;
-
-        // Init Apps Signals Id
-        this._appStateChangedSignalId = null;
-        this._appDisplayChangedSignalId = null;
-        this._appWorkspaceChangedSignalId = null;
-        this._appAddWindowSignalId = null;
-        this._appRemoveWindowSignalId = null;
+        this._state = false;
 
         // Add indicator label for the timer
         this._timerLabel = new St.Label({
@@ -330,75 +555,26 @@ class Caffeine extends QuickSettings.SystemIndicator {
         }
         this._indicator.gicon = this._iconDeactivated;
 
-        // Manage night light
-        this._nightLight = false;
-
-        /* Inhibited flag value
-        * - 4: Inhibit suspending the session or computer
-        * - 12: Inhibit the session being marked as idle
-        */
-        this.inhibitFlags = 12;
-
-        // Caffeine state
-        this._state = false;
-        this._userState = false;
-
-        // Store the inhibition requests until processed
-        this._inhibitionAddedFifo = [];
-        this._inhibitionRemovedFifo = [];
-
-        // Init inhibitor signals
-        this._inhibitorAddedId = null;
-        this._inhibitorRemovedId = null;
-
         // Init Timers
         this._timeOut = null;
         this._timePrint = null;
         this._timerEnable = false;
-        this._timeFullscreen = null;
-        this._timeWorkspaceAdd = null;
-        this._timeWorkspaceRemove = null;
         this._timeAppUnblock = null;
 
         // Show icon
         this._manageShowIndicator();
 
-        // Init app list
-        this._appConfigs = [];
-        this._appInhibitedData = new Map();
-        this._updateAppConfigs();
-
-        // Enable caffeine when fullscreen app is running
-        if (this._settings.get_boolean(FULLSCREEN_KEY)) {
-            global.display.connectObject('in-fullscreen-changed',
-                () => this.toggleFullscreen(), this);
-            this.toggleFullscreen();
-        }
-
-        // QuickSettings
+        // Quick Settings
         this._caffeineToggle = new CaffeineToggle(Me);
+
         this.quickSettingsItems.push(this._caffeineToggle);
         this._updateTimerSubtitle();
 
-        // Init settings keys and restore user state
-        this._settings.reset(TOGGLE_STATE_KEY);
-        if (this._settings.get_boolean(USER_ENABLED_KEY) && this._settings.get_boolean(RESTORE_KEY)) {
-            this.toggleState();
-        } else {
-            // reset user state
-            this._settings.reset(USER_ENABLED_KEY);
-        }
+        this._caffeineToggle.connectObject('clicked', () => this._handleToggleClick(), this);
+        this._caffeineToggle.connectObject('timer-clicked', () => this._forceToggleClick(), this);
 
-        // Bind signals
-        this._inhibitorAddedId = this._sessionManager.connectSignal('InhibitorAdded',
-            this._inhibitorAdded.bind(this));
-        this._inhibitorRemovedId = this._sessionManager.connectSignal('InhibitorRemoved',
-            this._inhibitorRemoved.bind(this));
+        // Bind settings signals
         this._settings.connectObject(
-            `changed::${INHIBIT_APPS_KEY}`,
-            () => this._updateAppConfigs(),
-            `changed::${TOGGLE_STATE_KEY}`,
-            () => this._updateMainState(),
             `changed::${TIMER_KEY}`,
             () => this._startTimer(),
             `changed::${SHOW_TIMER_KEY}`,
@@ -409,11 +585,6 @@ class Caffeine extends QuickSettings.SystemIndicator {
             () => {
                 this._manageShowIndicator();
                 this._showIndicatorLabel();
-            },
-            `changed::${TRIGGER_APPS_MODE}`,
-            () => {
-                this._resetAppSignalId();
-                this._updateAppEventMode();
             },
             this);
 
@@ -447,94 +618,40 @@ class Caffeine extends QuickSettings.SystemIndicator {
             QuickSettingsMenu._indicators.remove_actor(this);
         }
         QuickSettingsMenu._indicators.insert_child_at_index(this, this.indicatorIndex);
-    }
 
-    get inFullscreen() {
-        let nbMonitors = global.display.get_n_monitors();
-        let inFullscreen = false;
-        for (let i = 0; i < nbMonitors; i++) {
-            if (global.display.get_monitor_in_fullscreen(i)) {
-                inFullscreen = true;
-                break;
-            }
-        }
-        return inFullscreen;
-    }
+        // Setup inhibitor manager
+        this._inhibitorManager = new InhibitorManager(this._settings);
+        this._inhibitorManager.connectObject('update', () => this._inhibitorUpdated(), this);
 
-    toggleFullscreen() {
-        /* Reset previous FullScreen delay
-        * This prevent multiple inhibitors to be created in toggleFullscreen()
-        * if a previous timer is still running.
-        */
-        if (this._timeFullscreen !== null) {
-            GLib.Source.remove(this._timeFullscreen);
-            this._timeFullscreen = null;
-        }
-
-        this._manageScreenBlankState(false);
-
-        // Add 2 second delay before adding inhibitor
-        this._timeFullscreen = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 2, () => {
-            if (this.inFullscreen && !this._appInhibitedData.has('fullscreen')) {
-                this.addInhibit('fullscreen');
-                this._manageNightLight(false, false);
-            }
-
-            this._timeFullscreen = null;
-            return GLib.SOURCE_REMOVE;
-        });
-
-        if (!this.inFullscreen && this._appInhibitedData.has('fullscreen')) {
-            this.removeInhibit('fullscreen');
-            this._manageNightLight(true, false);
+        // Set manager user state and restore user state, if required
+        if (this._settings.get_boolean(USER_ENABLED_KEY) &&
+            this._settings.get_boolean(RESTORE_KEY)) {
+            // Restore Caffeine as enabled (fake a user click)
+            this._forceToggleClick();
         }
     }
 
-    toggleState() {
-        this._manageScreenBlankState(false);
+    _forceToggleClick() {
+        this._state = false;
+        this._handleToggleClick();
+    }
+
+    _handleToggleClick() {
+        // Pass the new user state to the inhibitor manager, causes state to invert
+        this._inhibitorManager.setUserEnabled(!this._state);
+        this._settings.set_boolean(USER_ENABLED_KEY, this._state);
+
         if (this._state) {
-            this._removeTimer();
-            this._appInhibitedData.forEach((data, appId) =>
-                this.removeInhibit(appId)
-            );
-            this._manageNightLight(true, false);
-        } else {
-            this.addInhibit('user');
-            this._manageNightLight(false, false);
-
-            // Enable timer when duration isn't null
+            // Enable timer when toggled on and duration is set
             if (this._settings.get_int(TIMER_KEY) !== 0 && !this._timerEnable) {
                 this._startTimer();
             }
+        } else {
+            // Enable timer when toggled off
+            this._removeTimer();
         }
+
         this._updateMaxPosition();
-    }
-
-    addInhibit(appId) {
-        this._sessionManager.InhibitRemote(appId,
-            0, 'Inhibit by %s'.format(this._name), this.inhibitFlags,
-            (cookie) => {
-                this._inhibitionAddedFifo.push(appId);
-                // Init app data
-                let data = {
-                    cookie,
-                    isToggled: true,
-                    isInhibited: false,
-                    object: ''
-                };
-                this._appInhibitedData.set(appId, data);
-            }
-        );
-    }
-
-    removeInhibit(appId) {
-        let appData = this._appInhibitedData.get(appId);
-        if (appData && appData.isInhibited) {
-            this._inhibitionRemovedFifo.push(appId);
-            this._sessionManager.UninhibitRemote(appData.cookie);
-            appData.isToggled = false;
-            this._appInhibitedData.set(appId, appData);
-        }
     }
 
     _incrementIndicatorPosIndex() {
@@ -570,7 +687,8 @@ class Caffeine extends QuickSettings.SystemIndicator {
             let targetIndicator =
                 QuickSettingsMenu._indicators.get_child_at_index(this.indicatorIndex);
             let maxIndex = QuickSettingsMenu._indicators.get_n_children();
-            while (this.indicatorIndex < maxIndex && !targetIndicator.is_visible() && this.indicatorIndex > -1) {
+            while (this.indicatorIndex < maxIndex && !targetIndicator.is_visible() &&
+                   this.indicatorIndex > -1) {
                 this._incrementIndicatorPosIndex();
                 targetIndicator =
                     QuickSettingsMenu._indicators.get_child_at_index(this.indicatorIndex);
@@ -628,7 +746,9 @@ class Caffeine extends QuickSettings.SystemIndicator {
             this._timeOut = GLib.timeout_add(GLib.PRIORITY_DEFAULT, timerDelay * 1000, () => {
                 // Disable Caffeine when timer ended
                 this._removeTimer();
-                this._settings.set_boolean(TOGGLE_STATE_KEY, false);
+                if (this._state) {
+                    this._handleToggleClick();
+                }
                 return GLib.SOURCE_REMOVE;
             });
         }
@@ -665,7 +785,8 @@ class Caffeine extends QuickSettings.SystemIndicator {
 
     _updateLabelTimer(text) {
         this._timerLabel.text = text;
-        this._caffeineToggle.menu.setHeader(this._caffeineToggle.finalTimerMenuIcon, _('Caffeine Timer'), text);
+        this._caffeineToggle.menu.setHeader(this._caffeineToggle.finalTimerMenuIcon,
+            _('Caffeine Timer'), text);
         this._caffeineToggle.subtitle = text;
     }
 
@@ -674,7 +795,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
         case Clutter.ScrollDirection.UP:
             if (!this._state) {
                 // User state on - UP
-                this._settings.set_boolean(TOGGLE_STATE_KEY, true);
+                this._handleToggleClick();
             }
             break;
         case Clutter.ScrollDirection.DOWN:
@@ -682,167 +803,83 @@ class Caffeine extends QuickSettings.SystemIndicator {
                 // Stop timer
                 this._removeTimer();
                 // User state off - DOWN
-                this._settings.set_boolean(TOGGLE_STATE_KEY, false);
+                this._handleToggleClick();
             }
             break;
         }
     }
 
-    _inhibitorAdded(proxy, sender, [object]) {
-        this._sessionManager.GetInhibitorsRemote(([inhibitors]) => {
-            // Get the first added request
-            let requestedId = this._inhibitionAddedFifo.shift();
+    _inhibitorUpdated() {
+        // Update the tracked state
+        let oldState = this._state;
+        this._state = this._inhibitorManager.getInhibitState();
 
-            for (let i of inhibitors) {
-                let inhibitor = new DBusSessionManagerInhibitorProxy(Gio.DBus.session,
-                    'org.gnome.SessionManager',
-                    i);
-                inhibitor.GetAppIdRemote((appId) => {
-                    appId = String(appId);
-                    let appData = this._appInhibitedData.get(appId);
-                    if (appId !== '' && requestedId === appId && appData) {
-                        appData.isInhibited = true;
-                        appData.object = object;
-                        this._appInhibitedData.set(appId, appData);
+        // Update the visual state and subtitle
+        this._caffeineToggle.checked = this._state;
+        this._caffeineToggle.updateIcon();
+        this._updateAppSubtitle(this._inhibitorManager.getInhibitApp());
 
-                        if (appId === 'user') {
-                            this._saveUserState(true);
-                        } else {
-                            this._updateAppSubtitle(appId);
-                        }
-
-                        // Update state
-                        if (this._state === false) {
-                            this._saveMainState(true);
-                            // Indicator icon
-                            this._manageShowIndicator();
-                            this._indicator.gicon = this._iconActivated;
-
-                            // Shell OSD notifications
-                            if (this._settings.get_boolean(SHOW_NOTIFICATIONS_KEY) && !this.inFullscreen) {
-                                this._sendOSDNotification(true);
-                            }
-                        }
-                    }
-                });
-            }
-        });
-    }
-
-    /* eslint-disable no-unused-vars */
-    _inhibitorRemoved(proxy, sender, [object]) {
-    /* eslint-enable no-unused-vars */
-        // Get the first removed request
-        let appId = this._inhibitionRemovedFifo.shift();
-
-        if (appId) {
-            let appData = this._appInhibitedData.get(appId);
-            if (appData) {
-                // Remove app from list
-                this._appInhibitedData.delete(appId);
-
-                if (appId === 'user') {
-                    this._saveUserState(false);
-                } else {
-                    this._updateAppSubtitle(null);
-                }
-
-                // Update state
-                if (this._appInhibitedData.size === 0) {
-                    this._saveMainState(false);
-
-                    // Indicator icon
-                    this._manageShowIndicator();
-                    this._indicator.gicon = this._iconDeactivated;
-
-                    // Shell OSD notifications
-                    if (this._settings.get_boolean(SHOW_NOTIFICATIONS_KEY)) {
-                        this._sendOSDNotification(false);
-                    }
-                }
+        // Send an OSD notification, if enabled and state changed
+        if (this._state !== oldState) {
+            if (this._settings.get_boolean(SHOW_NOTIFICATIONS_KEY) &&
+                !this._inhibitorManager.isFullscreen()) {
+                this._sendOSDNotification(this._state);
             }
         }
-    }
 
-    _isToggleInhibited(appId) {
-        let appData = this._appInhibitedData.get(appId);
-        if (appData && appData.isToggled) {
-            return true;
-        } else {
-            return false;
-        }
+        // Update indicator, icon and subtitle
+        this._manageShowIndicator();
+        this._updateTimerSubtitle();
     }
 
     _manageShowIndicator() {
         if (this._state) {
             this._indicator.visible = this._settings.get_enum(SHOW_INDICATOR_KEY) !== ShowIndicator.NEVER;
+            this._indicator.gicon = this._iconActivated;
         } else {
             this._indicator.visible = this._settings.get_enum(SHOW_INDICATOR_KEY) === ShowIndicator.ALWAYS;
-        }
-    }
-
-    _manageScreenBlankState(isApp) {
-        let blankState = this._settings.get_enum(SCREEN_BLANK) === ControlContext.ALWAYS;
-        if (isApp) {
-            blankState = this._settings.get_enum(SCREEN_BLANK) > ControlContext.NEVER;
-        }
-
-        if (blankState) {
-            this.inhibitFlags = 4;
-        } else {
-            this.inhibitFlags = 12;
-        }
-    }
-
-    _manageNightLight(isEnable, isApp) {
-        let nightLightPref = this._settings.get_enum(NIGHT_LIGHT_KEY) === ControlContext.ALWAYS;
-        if (isApp) {
-            nightLightPref = this._settings.get_enum(NIGHT_LIGHT_KEY) > ControlContext.NEVER;
-        }
-        if (isEnable && (nightLightPref || this._nightLight && this._proxy.DisabledUntilTomorrow)) {
-            this._proxy.DisabledUntilTomorrow = false;
-            this._nightLight = false;
-        } else if (!isEnable && nightLightPref) {
-            this._proxy.DisabledUntilTomorrow = true;
-            this._nightLight = true;
+            this._indicator.gicon = this._iconDeactivated;
         }
     }
 
     _sendOSDNotification(state) {
-        const nightLightPref =
-            this._settings.get_enum(NIGHT_LIGHT_KEY) !== ControlContext.NEVER;
-        if (state) {
-            let message = _('Caffeine enabled');
-            if (nightLightPref && this._nightLight && this._proxy.NightLightActive) {
+        let message = _('Caffeine enabled');
+        let icon = this._iconActivated;
+        if (!state) {
+            message = _('Caffeine disabled');
+            icon = this._iconDeactivated;
+        }
+
+        if (this._inhibitorManager.isNightLightManaged()) {
+            if (this._inhibitorManager.isNightLightOn()) {
+                message = message + '. ' + _('Night Light resumed');
+            } else {
                 message = message + '. ' + _('Night Light paused');
             }
-            Main.osdWindowManager.show(-1, this._iconActivated,
-                message, null, null);
-        } else {
-            let message = _('Caffeine disabled');
-            if (nightLightPref && !this._nightLight && this._proxy.NightLightActive) {
-                message = message + '. ' + _('Night Light resumed');
-            }
-            Main.osdWindowManager.show(-1, this._iconDeactivated,
-                message, null, null);
         }
+
+        Main.osdWindowManager.show(-1, icon, message, null, null);
     }
 
-    // Add the name of App as subtitle
-    _updateAppSubtitle(id) {
-        const listAppId = this._appInhibitedData.keys();
-        let appId = id !== null ? id : listAppId.next().value;
-        if (appId !== undefined) {
-            let appInfo = Gio.DesktopAppInfo.new(appId);
-            this._caffeineToggle.subtitle = appInfo !== null
-                ? appInfo.get_display_name()
-                : null;
+    // Add the name of the app as subtitle
+    _updateAppSubtitle(appId) {
+        if (appId === null) {
+            this._caffeineToggle.subtitle = null;
+            return;
         }
+
+        let app = this._appSystem.lookup_app(appId);
+        if (app === null) {
+            this._caffeineToggle.subtitle = null;
+            return;
+        }
+
+        this._caffeineToggle.subtitle = app.get_name();
     }
 
     // Add the timer duration selected as subtitle
     _updateTimerSubtitle() {
-        if (!this._settings.get_boolean(TOGGLE_STATE_KEY)) {
+        if (!this._state) {
             const timerDuration = this._settings.get_int(TIMER_KEY);
             const hours = Math.floor(timerDuration / 3600);
             const min = Math.floor((timerDuration % 3600) / 60);
@@ -873,254 +910,11 @@ class Caffeine extends QuickSettings.SystemIndicator {
         }
     }
 
-    _updateAppConfigs() {
-        this._appConfigs.length = 0;
-        this._settings.get_strv(INHIBIT_APPS_KEY).forEach((appId) => {
-            // Check if app still exist
-            const appInfo = Gio.DesktopAppInfo.new(appId);
-            if (appInfo) {
-                this._appConfigs.push(appId);
-            }
-        });
-
-        // Remove inhibited app that are not in the list anymore
-        let inhibitedAppsToRemove = [...this._appInhibitedData.keys()]
-            .filter((id) => !this._appConfigs.includes(id));
-        inhibitedAppsToRemove.forEach((id) => {
-            this._manageScreenBlankState(true); // Allow blank screen
-            this._manageNightLight(true, true);
-            this.removeInhibit(id); // Uninhibit app
-        });
-
-        this._updateAppEventMode();
-    }
-
-    _updateMainState() {
-        if (this._settings.get_boolean(TOGGLE_STATE_KEY) !== this._state) {
-            this.toggleState();
-        }
-        // Add timer duration as Subtitle when disable
-        this._updateTimerSubtitle();
-    }
-
-    _saveUserState(state) {
-        this._userState = state;
-        this._settings.set_boolean(USER_ENABLED_KEY, state);
-    }
-
-    _saveMainState(state) {
-        this._state = state;
-        this._settings.set_boolean(TOGGLE_STATE_KEY, state);
-    }
-
-    _resetAppSignalId() {
-        if (this._appStateChangedSignalId) {
-            this._appSystem.disconnect(this._appStateChangedSignalId);
-            this._appStateChangedSignalId = null;
-        }
-        if (this._appDisplayChangedSignalId) {
-            global.display.disconnect(this._appDisplayChangedSignalId);
-            this._appDisplayChangedSignalId = null;
-        }
-        if (this._appWorkspaceChangedSignalId) {
-            global.workspace_manager.disconnect(this._appWorkspaceChangedSignalId);
-            this._appWorkspaceChangedSignalId = null;
-        }
-        if (this._appAddWindowSignalId) {
-            this._activeWorkspace.disconnect(this._appAddWindowSignalId);
-            this._appAddWindowSignalId = null;
-        }
-        if (this._appRemoveWindowSignalId) {
-            this._activeWorkspace.disconnect(this._appRemoveWindowSignalId);
-            this._appRemoveWindowSignalId = null;
-        }
-    }
-
-    _updateAppEventMode() {
-        let appsTriggeredMode = this._settings.get_enum(TRIGGER_APPS_MODE);
-
-        if (this._appConfigs.length === 0) {
-            this._resetAppSignalId();
-        } else {
-            switch (appsTriggeredMode) {
-            // TRIGGER APPS MODE: ON RUNNING
-            case AppsTrigger.ON_RUNNING:
-                if (!this._appStateChangedSignalId) {
-                    this._appStateChangedSignalId =
-                        this._appSystem.connect('app-state-changed',
-                            this._appStateChanged.bind(this));
-                }
-                // Check if currently running App
-                this._appConfigs.forEach((id) => {
-                    let app = this._appSystem.lookup_app(id);
-                    if (app && app.get_state() !== Shell.AppState.STOPPED) {
-                        this._appStateChanged(this._appSystem, app);
-                    }
-                });
-                break;
-            // TRIGGER APPS MODE: ON FOCUS
-            case AppsTrigger.ON_FOCUS:
-                if (!this._appDisplayChangedSignalId) {
-                    this._appDisplayChangedSignalId =
-                        global.display.connect('notify::focus-window',
-                            this._appWindowFocusChanged.bind(this));
-                }
-                // Check if currently focused App
-                this._appWindowFocusChanged();
-                break;
-            // TRIGGER APPS MODE: ON ACTIVE WORKSPACE
-            case AppsTrigger.ON_ACTIVE_WORKSPACE:
-                if (!this._appWorkspaceChangedSignalId) {
-                    this._appWorkspaceChangedSignalId =
-                        global.workspace_manager.connect('workspace-switched',
-                            this._appWorkspaceChanged.bind(this));
-                }
-                // Check if App is currently on active workspace
-                this._appWorkspaceChanged();
-                break;
-            }
-        }
-    }
-
-    _toggleWorkspace() {
-        // Search for triggered apps on active workspace
-        this._appConfigs.forEach((appId) => {
-            let app = this._appSystem.lookup_app(appId);
-            let isOnWorkspace = app.is_on_workspace(this._activeWorkspace);
-            if (isOnWorkspace && !this._isToggleInhibited(appId)) {
-                this._manageScreenBlankState(true); // Allow blank screen
-                this._manageNightLight(false, true);
-                this.addInhibit(appId); // Inhibit app
-            } else if (!isOnWorkspace && this._isToggleInhibited(appId)) {
-                this._manageScreenBlankState(true); // Allow blank screen
-                this._manageNightLight(true, true);
-                this.removeInhibit(appId); // Uninhibit app
-            }
-        });
-    }
-
-    _appWorkspaceChanged() {
-        // Reset signal for Add/remove windows on workspace
-        if (this._appAddWindowSignalId) {
-            this._activeWorkspace.disconnect(this._appAddWindowSignalId);
-            this._appAddWindowSignalId = null;
-        }
-        if (this._appRemoveWindowSignalId) {
-            this._activeWorkspace.disconnect(this._appRemoveWindowSignalId);
-            this._appRemoveWindowSignalId = null;
-        }
-
-        // Get active workspace
-        this._activeWorkspace = global.workspace_manager.get_active_workspace();
-
-        // Add signal listener on add/remove windows for the active workspace
-        this._appAddWindowSignalId =
-            this._activeWorkspace.connect('window-added', (wkspace, window) => {
-                const type = window.get_window_type();
-                // Accept only normal window, ignore all other type (dialog, menu,...)
-                if (type === 0) {
-                    // Add 100 ms delay to handle window detection
-                    this._timeWorkspaceAdd = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
-                        this._toggleWorkspace();
-                        this._timeWorkspaceAdd = null;
-                        return GLib.SOURCE_REMOVE;
-                    });
-                }
-            });
-        this._appRemoveWindowSignalId =
-            this._activeWorkspace.connect('window-removed', (wkspace, window) => {
-                const type = window.get_window_type();
-                // Accept only normal window, ignore all other type (dialog, menu,...)
-                if (type === 0) {
-                    // Add 100 ms delay to handle window detection
-                    this._timeWorkspaceRemove = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
-                        this._toggleWorkspace();
-                        this._timeWorkspaceRemove = null;
-                        return GLib.SOURCE_REMOVE;
-                    });
-                }
-            });
-
-        // Check and toggle Caffeine
-        this._toggleWorkspace();
-    }
-
-    _appWindowFocusChanged() {
-        let winTrack = Shell.WindowTracker.get_default();
-        let appId = null;
-        let app = winTrack.focus_app;
-
-        if (app) {
-            appId = app.get_id();
-        }
-        if (this._appConfigs.includes(appId) && !this._isToggleInhibited(appId)) {
-            this._manageScreenBlankState(true); // Allow blank screen
-            this._manageNightLight(false, true);
-            this.addInhibit(appId); // Inhibit app
-
-            // Uninhibit previous focused apps
-            this._appInhibitedData.forEach((data, id) => {
-                if (id !== appId && id !== 'user') {
-                    this.removeInhibit(id);
-                }
-            });
-        } else if (!this._appConfigs.includes(appId) && this._appInhibitedData.size !== 0) {
-            this._manageScreenBlankState(true); // Allow blank screen
-            this._manageNightLight(true, true);
-            // Uninhibit all apps
-            this._appInhibitedData.forEach((data, id) => {
-                if (id !== 'user') {
-                    this.removeInhibit(id);
-                }
-            });
-        }
-    }
-
-    _appStateChanged(appSys, app) {
-        let appId = app.get_id();
-        let appState = app.get_state();
-
-        if (this._appConfigs.includes(appId)) {
-            // Block App state signal
-            appSys.block_signal_handler(this._appStateChangedSignalId);
-
-            // Allow blank screen
-            this._manageScreenBlankState(true);
-
-            if (appState === Shell.AppState.STOPPED && this._isToggleInhibited(appId)) {
-                this._manageNightLight(true, true);
-                this.removeInhibit(appId); // Uninhibit app
-            } else if (appState !== Shell.AppState.STOPPED && !this._isToggleInhibited(appId)) {
-                this._manageNightLight(false, true);
-                this.addInhibit(appId); // Inhibit app
-            }
-
-            // Add 200 ms delay before unblock state signal
-            this._timeAppUnblock = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 200, () => {
-                appSys.unblock_signal_handler(this._appStateChangedSignalId);
-                this._timeAppUnblock = null;
-                return GLib.SOURCE_REMOVE;
-            });
-        }
-    }
-
     destroy() {
-        // Remove all inhibitors
-        this._appInhibitedData.forEach((data, appId) => this.removeInhibit(appId));
-        this._appInhibitedData.clear();
-
         // Remove ToggleMenu
         this.quickSettingsItems.forEach((item) => item.destroy());
 
         // Disconnect from signals
-        if (this._inhibitorAddedId) {
-            this._sessionManager.disconnectSignal(this._inhibitorAddedId);
-            this._inhibitorAddedId = null;
-        }
-        if (this._inhibitorRemovedId) {
-            this._sessionManager.disconnectSignal(this._inhibitorRemovedId);
-            this._inhibitorRemovedId = null;
-        }
         if (this._timeOut) {
             GLib.Source.remove(this._timeOut);
             this._timeOut = null;
@@ -1129,25 +923,14 @@ class Caffeine extends QuickSettings.SystemIndicator {
             GLib.Source.remove(this._timePrint);
             this._timePrint = null;
         }
-        if (this._timeFullscreen) {
-            GLib.Source.remove(this._timeFullscreen);
-            this._timeFullscreen = null;
-        }
-        if (this._timeWorkspaceAdd) {
-            GLib.Source.remove(this._timeWorkspaceAdd);
-            this._timeWorkspaceAdd = null;
-        }
-        if (this._timeWorkspaceRemove) {
-            GLib.Source.remove(this._timeWorkspaceRemove);
-            this._timeWorkspaceRemove = null;
-        }
         if (this._timeAppUnblock) {
             GLib.Source.remove(this._timeAppUnblock);
             this._timeAppUnblock = null;
         }
-        this._resetAppSignalId();
 
-        this._appConfigs.length = 0;
+        this._inhibitorManager.destroy();
+        this._inhibitorManager = null;
+
         this._settings = null;
         super.destroy();
     }
@@ -1162,7 +945,7 @@ export default class CaffeineExtension extends Extension {
         Main.wm.addKeybinding(TOGGLE_SHORTCUT, this._settings,
             Meta.KeyBindingFlags.IGNORE_AUTOREPEAT,
             Shell.ActionMode.ALL, () => {
-                this._caffeineIndicator.toggleState();
+                this._caffeineIndicator._handleToggleClick();
             });
     }
 
@@ -1178,5 +961,3 @@ export default class CaffeineExtension extends Extension {
         this.openPreferences();
     }
 }
-
-

--- a/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
+++ b/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
@@ -114,8 +114,3 @@
     </key>
   </schema>
 </schemalist>
-
-
-
-
-

--- a/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
+++ b/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
@@ -22,11 +22,6 @@
         <summary>Application list</summary>
         <description>A list of strings, each containing an application id (desktop file name)</description>
     </key>
-    <key type="b" name="toggle-state">
-        <default>false</default>
-        <summary>Store caffeine toggle state</summary>
-        <description></description>
-    </key>
     <key type="b" name="user-enabled">
         <default>false</default>
         <summary>Store caffeine user state</summary>


### PR DESCRIPTION
This is a fairly extensive rewrite of `extension.js`, and I'm not proud of putting it in 1 commit, but absolutely nothing would work in the slightest until everything was moved over to an inhibitor manager, as I suggested in #285.

The current solution seems to create an inhibitor for every excuse to inhibit, which has lead to the extension losing track of its inhibitors in the past, and suffered from race conditions too. The new solution abstracts the inhibiting away to a new class, `InhibitorManager`. It connects to signals and calls `_updateState()`, which uses `_getInhibitReasons()` to scan every excuse to inhibit (user toggle, apps, fullscreen). It then compares these against the user's settings, and decides whether to inhibit or not, and updates the inhibitor and night light accordingly. This means we only every have 1 inhibitor, so we can't easily lose track of it. It also makes the app handling simpler, as we just add methods to handle the chosen app trigger, and return whichever app is responsible for triggering Caffeine.

This means adding new ways to enable and disable Caffeine just means making `_getInhibitReasons()` aware of them, making issues like #217, #307 and #330 much easier to approach.

In summary:
 - Slims down the codebase
 - Slims down DBus interfaces and GSettings schemas
 - Self-contains a lot of the code
 - Decouple the inhibitor logic and indicator logic
 - Creates the inhibitor synchronously, to put an end to the race conditions
 - Fixes #332 (I assume the old code got stuck in a loop of events)
 - Fixes a few miscellaneous bugs around triggering on workspaces

Any feedback and testing is appreciated :)

Closes #332