### PR TITLE
Add support for GNOME 47 to metadata

### DIFF
--- a/caffeine@patapon.info/metadata.json
+++ b/caffeine@patapon.info/metadata.json
@@ -1,7 +1,7 @@
 {
   "version": 53,
   "shell-version": [
-    "45", "46"
+    "45", "46", "47"
   ],
   "uuid": "caffeine@patapon.info",
   "name": "Caffeine",


### PR DESCRIPTION
Working without any changes, seems to be a fairly uneventful release cycle so far