### PR TITLE
Fix hungarian translation

### DIFF
--- a/caffeine@patapon.info/locale/hu.po
+++ b/caffeine@patapon.info/locale/hu.po
@@ -26,11 +26,11 @@ msgstr "Végtelen"
 
 #: extension.js:201 extension.js:829
 msgid " hour "
-msgstr " órá "
+msgstr " óra "
 
 #: extension.js:204 extension.js:832
 msgid " hours "
-msgstr " órák "
+msgstr " óra "
 
 #: extension.js:211
 msgid " minute"
@@ -38,7 +38,7 @@ msgstr " perc"
 
 #: extension.js:214 preferences/timerPage.js:211
 msgid " minutes"
-msgstr " percek"
+msgstr " perc"
 
 #: extension.js:790
 msgid "Caffeine enabled"


### PR DESCRIPTION
The Hungarian localization contains several errors, and with this PR, I would like to fix them.

![Képernyőkép 2024-11-07 10-28-20](https://github.com/user-attachments/assets/ff900d0f-d995-4083-8141-7b14c234489f)

"percek" -> "perc"
"órák" -> "óra"
"órá" -> does not exist in the hungarian language, contains a typo, "óra"