### PR TITLE
Feature: Timer Running Out Notification 

### DIFF
--- a/caffeine@patapon.info/preferences/displayPage.js
+++ b/caffeine@patapon.info/preferences/displayPage.js
@@ -70,10 +70,16 @@ class CaffeineDisplayPage extends Adw.PreferencesPage {
         });
 
         // Notifications
-        let notificationRow = new Adw.SwitchRow({
+        let showNotificationsList =  new Gtk.StringList();
+        showNotificationsList.append(_('Show state'));
+        showNotificationsList.append(_('Show timer running out'));
+        showNotificationsList.append(_('Show both'));
+        showNotificationsList.append(_('Disable'));
+        let showNotificationsRow = new Adw.ComboRow({
             title: _('Notifications'),
-            subtitle: _('Enable notifications when Caffeine is enabled or disabled'),
-            active: this._settings.get_boolean(this._settingsKey.SHOW_NOTIFICATIONS)
+            subtitle: _('Enable notifications for state changes or timer is running out'),
+            model: showNotificationsList,
+            selected: this._settings.get_enum(this._settingsKey.SHOW_NOTIFICATIONS_OPTS)
         });
 
         // Indicator position offset
@@ -95,7 +101,7 @@ class CaffeineDisplayPage extends Adw.PreferencesPage {
         displayGroup.add(showStatusIndicatorRow);
         displayGroup.add(showTimerRow);
         displayGroup.add(showToggleRow);
-        displayGroup.add(notificationRow);
+        displayGroup.add(showNotificationsRow);
         displayGroup.add(this.posIndicatorOffsetRow);
         this.add(displayGroup);
 
@@ -116,8 +122,22 @@ class CaffeineDisplayPage extends Adw.PreferencesPage {
         showToggleRow.connect('notify::active', (widget) => {
             this._settings.set_boolean(this._settingsKey.SHOW_TOGGLE, widget.get_active());
         });
-        notificationRow.connect('notify::active', (widget) => {
-            this._settings.set_boolean(this._settingsKey.SHOW_NOTIFICATIONS, widget.get_active());
+        showNotificationsRow.connect('notify::selected', (widget) => {
+            let showNotifications = false;
+            let showNotificationsTimer = false;
+            if (widget.selected === 0) {
+                showNotifications = true;
+            } else if (widget.selected === 1) {
+                showNotificationsTimer = true;
+            } else if (widget.selected === 2) {
+                showNotifications = true;
+                showNotificationsTimer = true;
+            }
+
+            console.log(`${showNotifications}  ${showNotificationsTimer}`);
+
+            this._settings.set_boolean(this._settingsKey.SHOW_NOTIFICATIONS, showNotifications);
+            this._settings.set_boolean(this._settingsKey.SHOW_NOTIFICATIONS_TIMER, showNotificationsTimer);
         });
         this._settings.bind(this._settingsKey.INDICATOR_POSITION,
             this.posIndicatorOffsetRow, 'value',

--- a/caffeine@patapon.info/prefs.js
+++ b/caffeine@patapon.info/prefs.js
@@ -33,7 +33,9 @@ import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/
 const SettingsKey = {
     INHIBIT_APPS: 'inhibit-apps',
     SHOW_INDICATOR: 'show-indicator',
+    SHOW_NOTIFICATIONS_OPTS: 'show-notifications-opts',
     SHOW_NOTIFICATIONS: 'show-notifications',
+    SHOW_NOTIFICATIONS_TIMER: 'show-notifications-timer',
     SHOW_TIMER: 'show-timer',
     SHOW_TOGGLE: 'show-toggle',
     DURATION_TIMER_INDEX: 'duration-timer',

--- a/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
+++ b/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
@@ -4,6 +4,12 @@
         <value value="0" nick="never"/>
         <value value="1" nick="always"/>
         <value value="2" nick="for-apps"/>
+    </enum>
+    <enum id="org.gnome.shell.extensions.caffeine.show-notifications-opts">
+        <value value="0" nick="state"/>
+        <value value="1" nick="timer-run-out"/>
+        <value value="2" nick="both"/>
+        <value value="3" nick="disable"/>
    </enum>
    <enum id="org.gnome.shell.extensions.caffeine.show-indicator">
         <value value="0" nick="only-active"/>
@@ -57,10 +63,20 @@
         <summary>Show indicator</summary>
         <description>Show the indicator on the top panel</description>
     </key>
+    <key name="show-notifications-opts" enum="org.gnome.shell.extensions.caffeine.show-notifications-opts">
+        <default>"both"</default>
+        <summary>Show notifications</summary>
+        <description>Show notifications when state changes or timer is running out</description>
+    </key>
     <key type="b" name="show-notifications">
         <default>true</default>
         <summary>Show notifications</summary>
-        <description>Show notifications when enabled/disabled</description>
+        <description>Show notifications when state changes</description>
+    </key>
+    <key type="b" name="show-notifications-timer">
+        <default>true</default>
+        <summary>Show notifications</summary>
+        <description>Show notifications when timer is running out</description>
     </key>
     <key type="b" name="show-timer">
         <default>true</default>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fd28bbfe-474e-4d42-81e4-6018dab4d48f)


Preferences Page Changed:
![image](https://github.com/user-attachments/assets/59055c67-713d-4b7b-a110-353d4767c566)
New Options for Notifications setting:
- Show state
- Show timer running out
- Show both
- Disable

others:
- Notification Action Buttons Follows default or custom timers.
- Notification is handled for one instance only to avoid multiple notifications of the same context.
- Notification is canceled on interrupt (such as triggering the quick settings toggle for caffeine)
- No breaking changes for OSD notification 