### PR TITLE
Replace Depracated App Chooser with Custom One

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -47,6 +47,7 @@ const DURATION_TIMER_LIST = 'duration-timer-list';
 const USER_ENABLED_KEY = 'user-enabled';
 const RESTORE_KEY = 'restore-state';
 const FULLSCREEN_KEY = 'enable-fullscreen';
+const INSTALLED_CHANGED_KEY = 'installed-changed';
 const MPRIS_KEY = 'enable-mpris';
 const NIGHT_LIGHT_KEY = 'nightlight-control';
 const TOGGLE_SHORTCUT = 'toggle-shortcut';
@@ -630,9 +631,17 @@ class Caffeine extends QuickSettings.SystemIndicator {
     _init(Me) {
         super._init();
 
-        this._appSystem = Shell.AppSystem.get_default();
-        this._indicator = this._addIndicator();
+
         this._settings = Me._settings;
+
+        this._appSystem = Shell.AppSystem.get_default();
+        this._appSystemInstalledChangedId = this._appSystem.connect('installed-changed', () => {
+            this._settings.set_boolean(
+                INSTALLED_CHANGED_KEY,
+                !this._settings.get_boolean(INSTALLED_CHANGED_KEY)
+            );
+        });
+        this._indicator = this._addIndicator();
         this._name = Me.metadata.name;
         this._state = false;
 
@@ -1014,6 +1023,11 @@ class Caffeine extends QuickSettings.SystemIndicator {
     destroy() {
         // Remove ToggleMenu
         this.quickSettingsItems.forEach((item) => item.destroy());
+
+        if (this._appSystemInstalledChangedId) {
+            this._appSystem.disconnect(this._appSystemInstalledChangedId);
+            this._appSystemInstalledChangedId = null;
+        }
 
         // Disconnect from signals
         if (this._timeOut) {

--- a/caffeine@patapon.info/preferences/appsPage.js
+++ b/caffeine@patapon.info/preferences/appsPage.js
@@ -165,7 +165,7 @@ class CaffeineAppsPage extends Adw.PreferencesPage {
     }
 
     _onAddApp() {
-        const dialog = new AppChooser(this.get_root());
+        const dialog = new AppChooser(this.get_root(), this._settings, this._settingsKey);
         dialog.connect('response', (dlg, id) => {
             const appInfo = id === AppChooser.ResponseType.OK
                 ? dlg.appInfo : null;

--- a/caffeine@patapon.info/prefs.js
+++ b/caffeine@patapon.info/prefs.js
@@ -33,6 +33,7 @@ import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/
 const SettingsKey = {
     INHIBIT_APPS: 'inhibit-apps',
     SHOW_INDICATOR: 'show-indicator',
+    INSTALLED_CHANGED: 'installed-changed',
     SHOW_NOTIFICATIONS: 'show-notifications',
     SHOW_TIMER: 'show-timer',
     SHOW_TOGGLE: 'show-toggle',

--- a/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
+++ b/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
@@ -22,6 +22,12 @@
         <summary>Application list</summary>
         <description>A list of strings, each containing an application id (desktop file name)</description>
     </key>
+    <key type="b" name="installed-changed">
+        <default>false</default>
+        <summary>True or False flip to indicate install list changed</summary>
+        <description></description>
+    </key>
+
     <key type="b" name="user-enabled">
         <default>false</default>
         <summary>Store caffeine user state</summary>


### PR DESCRIPTION
Stated in ![gjs-docs](https://gjs-docs.gnome.org/gtk40~4.0/gtk.appchooser)
![image](https://github.com/user-attachments/assets/e6b24db3-ab28-48d6-a60e-23d5a46c0870)


Custom Implementation Requires Gtk.Window or Adw.Window as Base Class.
Gtk TreeView is also depracted replaced by Gtk.ListView

### new app chooser as of this PR
![image](https://github.com/user-attachments/assets/57eb7faf-5c56-40e6-80f9-255c00ab43af)
<br>
made it as close as the original one.

### todo
- [x]  implement double click handling on single selection item 
- [ ]  handle Force Quit
- [x]  auto refresh app list when new app is installed or uninstalled
- [x] handled proper Tab Navigation
- [x]  handle scroll bug
- [x]  updated source to smaller chunnks
- [ ]  clean up source (eg. change all call backs to callername + CB as prefix)