### PR TITLE
Use GioUnix.DesktopAppInfo on GNOME 49+

### DIFF
--- a/caffeine@patapon.info/preferences/appsPage.js
+++ b/caffeine@patapon.info/preferences/appsPage.js
@@ -26,6 +26,15 @@ import Gio from 'gi://Gio';
 
 import { gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
+import * as Config from 'resource:///org/gnome/Shell/Extensions/js/misc/config.js';
+const ShellVersion = parseFloat(Config.PACKAGE_VERSION);
+
+// Required for GNOME 49, without breaking on earlier shells
+let GioUnix;
+try {
+    GioUnix = (await import('gi://GioUnix?version=2.0')).default;
+} catch {}
+
 export var AppsPage = GObject.registerClass(
 class CaffeineAppsPage extends Adw.PreferencesPage {
     _init(settings, settingsKey) {
@@ -93,7 +102,12 @@ class CaffeineAppsPage extends Adw.PreferencesPage {
 
         // Update the list & Check if app still exist
         _apps.forEach((id) => {
-            const appInfo = Gio.DesktopAppInfo.new(id);
+            let appInfo = null;
+            if (ShellVersion >= 49) {
+                appInfo = GioUnix.DesktopAppInfo.new(id);
+            } else {
+                appInfo = Gio.DesktopAppInfo.new(id);
+            }
 
             if (appInfo) {
                 this._listApps.push(id);
@@ -132,7 +146,12 @@ class CaffeineAppsPage extends Adw.PreferencesPage {
                     });
 
                     // App info
-                    let appInfo = Gio.DesktopAppInfo.new(this._listApps[i]);
+                    let appInfo = null;
+                    if (ShellVersion >= 49) {
+                        appInfo = GioUnix.DesktopAppInfo.new(this._listApps[i]);
+                    } else {
+                        appInfo = Gio.DesktopAppInfo.new(this._listApps[i]);
+                    }
                     const appIcon = new Gtk.Image({
                         gicon: appInfo.get_icon(),
                         pixel_size: 32


### PR DESCRIPTION
GNOME 49 has moved `Gio.DesktopAppInfo` to `GioUnix.DesktopAppInfo`. It seems like it's supposed to just give a warning when it's not used, but currently it gives an error and breaks the preferences page.

`GioUnix` isn't available on some earlier shells that we support, so dynamically import it and catch any errors, then use it for GNOME 49+.