### PR TITLE
Enable 'prefer-const' eslint rule

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -234,11 +234,11 @@ const InhibitorManager = GObject.registerClass({
     }
 
     _findRunningApp() {
-        let possibleTriggerApps = this._settings.get_strv(INHIBIT_APPS_KEY);
-        let runningApps = this._appSystem.get_running();
+        const possibleTriggerApps = this._settings.get_strv(INHIBIT_APPS_KEY);
+        const runningApps = this._appSystem.get_running();
 
-        for (let app of runningApps) {
-            let appId = app.get_id();
+        for (const app of runningApps) {
+            const appId = app.get_id();
             if (possibleTriggerApps.includes(appId)) {
                 return appId;
             }
@@ -248,10 +248,10 @@ const InhibitorManager = GObject.registerClass({
     }
 
     _findFocusedApp() {
-        let possibleTriggerApps = this._settings.get_strv(INHIBIT_APPS_KEY);
-        let focusedApp = Shell.WindowTracker.get_default().focus_app;
+        const possibleTriggerApps = this._settings.get_strv(INHIBIT_APPS_KEY);
+        const focusedApp = Shell.WindowTracker.get_default().focus_app;
         if (focusedApp !== null) {
-            let appId = focusedApp.get_id();
+            const appId = focusedApp.get_id();
             if (possibleTriggerApps.includes(appId)) {
                 return appId;
             }
@@ -261,11 +261,11 @@ const InhibitorManager = GObject.registerClass({
     }
 
     _findActiveApp() {
-        let possibleTriggerApps = this._settings.get_strv(INHIBIT_APPS_KEY);
-        let activeWorkspace = global.workspace_manager.get_active_workspace();
+        const possibleTriggerApps = this._settings.get_strv(INHIBIT_APPS_KEY);
+        const activeWorkspace = global.workspace_manager.get_active_workspace();
 
-        for (let appId of possibleTriggerApps) {
-            let app = this._appSystem.lookup_app(appId);
+        for (const appId of possibleTriggerApps) {
+            const app = this._appSystem.lookup_app(appId);
             if (app !== null) {
                 if (app.is_on_workspace(activeWorkspace)) {
                     return appId;
@@ -277,7 +277,7 @@ const InhibitorManager = GObject.registerClass({
     }
 
     _getInhibitReasons() {
-        let reasons = [];
+        const reasons = [];
         if (this.isFullscreen() && this._settings.get_boolean(FULLSCREEN_KEY)) {
             reasons.push('fullscreen');
         }
@@ -335,7 +335,7 @@ const InhibitorManager = GObject.registerClass({
         // Ignore any reasons in the ignore list, then save them
         reasons = reasons.filter((n) => !this._ignoredReasons.includes(n));
         this._lastReasons = [...reasons];
-        let shouldInhibit = reasons.length !== 0;
+        const shouldInhibit = reasons.length !== 0;
 
         /* If no trigger app is running, and the light is in app-only mode,
            and we left it blocked, unblock it
@@ -393,16 +393,16 @@ const InhibitorManager = GObject.registerClass({
         }
 
         // Pack the parameters for DBus
-        let params = [
+        const params = [
             GLib.Variant.new_string('caffeine-gnome-extension'),
             GLib.Variant.new_uint32(0),
             GLib.Variant.new_string('Inhibit by %s'.format(this._name)),
             GLib.Variant.new_uint32(inhibitFlags)
         ];
-        let paramsVariant = GLib.Variant.new_tuple(params);
+        const paramsVariant = GLib.Variant.new_tuple(params);
 
         // Synchronously add the inhibitor
-        let cookieTuple = this._sessionManager.call_sync('Inhibit', paramsVariant,
+        const cookieTuple = this._sessionManager.call_sync('Inhibit', paramsVariant,
             Gio.DBusCallFlags.NONE, -1, null);
         if (cookieTuple !== null) {
             this._inhibitorCookie = cookieTuple.get_child_value(0).get_uint32();
@@ -423,7 +423,7 @@ const InhibitorManager = GObject.registerClass({
     }
 
     isFullscreen() {
-        let monitorCount = global.display.get_n_monitors();
+        const monitorCount = global.display.get_n_monitors();
         for (let i = 0; i < monitorCount; i++) {
             if (global.display.get_monitor_in_fullscreen(i)) {
                 return true;
@@ -551,7 +551,7 @@ const CaffeineToggle = GObject.registerClass({
         this._itemsSection.removeAll();
         this._timerItems.clear();
         // Get duration list and add '0' for the 'infinite' entry (no timer)
-        let durationValues = this._settings.get_value(DURATION_TIMER_LIST).deepUnpack();
+        const durationValues = this._settings.get_value(DURATION_TIMER_LIST).deepUnpack();
         durationValues.push(0);
 
         // Create menu timer
@@ -560,8 +560,8 @@ const CaffeineToggle = GObject.registerClass({
             if (timer === 0) {
                 label = _('Infinite');
             } else {
-                let hours = Math.floor(timer / 3600);
-                let minutes = Math.floor((timer % 3600) / 60);
+                const hours = Math.floor(timer / 3600);
+                const minutes = Math.floor((timer % 3600) / 60);
                 switch (hours) {
                 case 0:
                     break;
@@ -768,7 +768,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
 
     _updateMaxPosition() {
         let pos = -1;
-        let indicators = QuickSettingsMenu._indicators.get_children();
+        const indicators = QuickSettingsMenu._indicators.get_children();
 
         // Count visible items in the status area
         indicators.forEach((indicator) => {
@@ -790,7 +790,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
             // Skip invisible indicator
             let targetIndicator =
                 QuickSettingsMenu._indicators.get_child_at_index(this.indicatorIndex);
-            let maxIndex = QuickSettingsMenu._indicators.get_n_children();
+            const maxIndex = QuickSettingsMenu._indicators.get_n_children();
             while (this.indicatorIndex < maxIndex && !targetIndicator.is_visible() &&
                    this.indicatorIndex > -1) {
                 this._incrementIndicatorPosIndex();
@@ -834,7 +834,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
         this._timerEnable = true;
 
         // Get duration
-        let timerDelay = this._settings.get_int(TIMER_KEY);
+        const timerDelay = this._settings.get_int(TIMER_KEY);
 
         // Execute Timer only if duration isn't set on infinite time
         if (timerDelay !== 0) {
@@ -915,7 +915,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
 
     _inhibitorUpdated() {
         // Update the tracked state
-        let oldState = this._state;
+        const oldState = this._state;
         this._state = this._inhibitorManager.getInhibitState();
 
         // Update the visual state and subtitle
@@ -976,7 +976,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
             return;
         }
 
-        let app = this._appSystem.lookup_app(appId);
+        const app = this._appSystem.lookup_app(appId);
         if (app === null) {
             this._caffeineToggle.subtitle = null;
             return;

--- a/caffeine@patapon.info/preferences/appsPage.js
+++ b/caffeine@patapon.info/preferences/appsPage.js
@@ -49,16 +49,16 @@ class CaffeineAppsPage extends Adw.PreferencesPage {
 
         // Apps behavior group
         // --------------
-        let appsBehaviorGroup = new Adw.PreferencesGroup({
+        const appsBehaviorGroup = new Adw.PreferencesGroup({
             title: _('Trigger mode')
         });
 
         // Apps behavior select mode
-        let appsTriggerMode = new Gtk.StringList();
+        const appsTriggerMode = new Gtk.StringList();
         appsTriggerMode.append(_('Running'));
         appsTriggerMode.append(_('Focus'));
         appsTriggerMode.append(_('Active workspace'));
-        let appsTriggerModeRow = new Adw.ComboRow({
+        const appsTriggerModeRow = new Adw.ComboRow({
             title: _('Apps trigger Caffeine mode'),
             subtitle: _('Choose the way apps will trigger Caffeine'),
             model: appsTriggerMode,
@@ -71,7 +71,7 @@ class CaffeineAppsPage extends Adw.PreferencesPage {
 
         // Apps list group
         // --------------
-        let addAppsButton = new Gtk.Button({
+        const addAppsButton = new Gtk.Button({
             child: new Adw.ButtonContent({
                 icon_name: 'list-add-symbolic',
                 label: _('Add')
@@ -128,7 +128,7 @@ class CaffeineAppsPage extends Adw.PreferencesPage {
                 this.apps = {};
 
                 // Build new apps UI list
-                for (let i in this._listApps) {
+                for (const i in this._listApps) {
                     this.apps[i] = {};
                     this.apps[i].ButtonBox = new Gtk.Box({
                         orientation: Gtk.Orientation.HORIZONTAL,
@@ -170,7 +170,7 @@ class CaffeineAppsPage extends Adw.PreferencesPage {
                     this.appsGroup.add(this.apps[i].Row);
                 }
                 // Bind signals
-                for (let i in this.apps) {
+                for (const i in this.apps) {
                     this.apps[i].DeleteButton.connect('clicked', () => {
                         this._onRemoveApp(this._listApps[i]);
                     });

--- a/caffeine@patapon.info/preferences/displayPage.js
+++ b/caffeine@patapon.info/preferences/displayPage.js
@@ -39,16 +39,16 @@ class CaffeineDisplayPage extends Adw.PreferencesPage {
 
         // Display group
         // --------------
-        let displayGroup = new Adw.PreferencesGroup({
+        const displayGroup = new Adw.PreferencesGroup({
             title: _('Display')
         });
 
         // Show indicator
-        let showStatusIndicator = new Gtk.StringList();
+        const showStatusIndicator = new Gtk.StringList();
         showStatusIndicator.append(_('Only when active'));
         showStatusIndicator.append(_('Always'));
         showStatusIndicator.append(_('Never'));
-        let showStatusIndicatorRow = new Adw.ComboRow({
+        const showStatusIndicatorRow = new Adw.ComboRow({
             title: _('Show status indicator in top panel'),
             subtitle: _('Enable or disable the Caffeine icon in the top panel'),
             model: showStatusIndicator,
@@ -56,21 +56,21 @@ class CaffeineDisplayPage extends Adw.PreferencesPage {
         });
 
         // Show timer
-        let showTimerRow = new Adw.SwitchRow({
+        const showTimerRow = new Adw.SwitchRow({
             title: _('Show timer in top panel'),
             subtitle: _('Enable or disable the timer in the top panel'),
             active: this._settings.get_boolean(this._settingsKey.SHOW_TIMER)
         });
 
         // Show quick settings toggle
-        let showToggleRow = new Adw.SwitchRow({
+        const showToggleRow = new Adw.SwitchRow({
             title: _('Show quick settings toggle'),
             subtitle: _('Enable or disable the toggle in the quick settings menu'),
             active: this._settings.get_boolean(this._settingsKey.SHOW_TOGGLE)
         });
 
         // Notifications
-        let notificationRow = new Adw.SwitchRow({
+        const notificationRow = new Adw.SwitchRow({
             title: _('Notifications'),
             subtitle: _('Enable notifications when Caffeine is enabled or disabled'),
             active: this._settings.get_boolean(this._settingsKey.SHOW_NOTIFICATIONS)

--- a/caffeine@patapon.info/preferences/generalPage.js
+++ b/caffeine@patapon.info/preferences/generalPage.js
@@ -41,37 +41,37 @@ class CaffeineGeneralPage extends Adw.PreferencesPage {
 
         // Behavior group
         // --------------
-        let behaviorGroup = new Adw.PreferencesGroup({
+        const behaviorGroup = new Adw.PreferencesGroup({
             title: _('Behavior')
         });
 
         // Enable / disable fullscreen apps
-        let disableFullscreenRow = new Adw.SwitchRow({
+        const disableFullscreenRow = new Adw.SwitchRow({
             title: _('Enable for fullscreen apps'),
             subtitle: _('Automatically enable when an app enters fullscreen mode'),
             active: this._settings.get_boolean(this._settingsKey.FULLSCREEN)
         });
 
         // Enable / disable mpris apps
-        let enableMprisRow = new Adw.SwitchRow({
+        const enableMprisRow = new Adw.SwitchRow({
             title: _('Enable when an app is playing media'),
             subtitle: _('Automatically enable when an app reports playback'),
             active: this._settings.get_boolean(this._settingsKey.MPRIS)
         });
 
         // Remember state
-        let rememberStateRow = new Adw.SwitchRow({
+        const rememberStateRow = new Adw.SwitchRow({
             title: _('Remember state'),
             subtitle: _('Remember the last state across sessions and reboots'),
             active: this._settings.get_boolean(this._settingsKey.RESTORE)
         });
 
         // Pause and resume Night Light
-        let pauseNightLight = new Gtk.StringList();
+        const pauseNightLight = new Gtk.StringList();
         pauseNightLight.append(_('Never'));
         pauseNightLight.append(_('Always'));
         pauseNightLight.append(_('For apps on list'));
-        let pauseNightLightRow = new Adw.ComboRow({
+        const pauseNightLightRow = new Adw.ComboRow({
             title: _('Pause and resume Night Light'),
             subtitle: _('Toggles the night light together with Caffeine\'s state'),
             model: pauseNightLight,
@@ -79,11 +79,11 @@ class CaffeineGeneralPage extends Adw.PreferencesPage {
         });
 
         // Allow blank screen
-        let allowBlankScreen = new Gtk.StringList();
+        const allowBlankScreen = new Gtk.StringList();
         allowBlankScreen.append(_('Never'));
         allowBlankScreen.append(_('Always'));
         allowBlankScreen.append(_('For apps on list'));
-        let allowBlankScreenRow = new Adw.ComboRow({
+        const allowBlankScreenRow = new Adw.ComboRow({
             title: _('Allow screen blank'),
             subtitle: _('Allow turning off screen when Caffeine is enabled\n' +
                         'This may disable manual suspend / shutdown'),
@@ -101,14 +101,14 @@ class CaffeineGeneralPage extends Adw.PreferencesPage {
 
         // Shortcut group
         // --------------
-        let deleteShortcutButton = new Gtk.Button({
+        const deleteShortcutButton = new Gtk.Button({
             icon_name: 'edit-delete-symbolic',
             valign: Gtk.Align.CENTER,
             css_classes: ['error'],
             hexpand: false,
             vexpand: false
         });
-        let shortcutGroup = new Adw.PreferencesGroup({
+        const shortcutGroup = new Adw.PreferencesGroup({
             title: _('Shortcut'),
             header_suffix: deleteShortcutButton
         });
@@ -227,9 +227,9 @@ const ShortcutSettingWidget = class extends Adw.ActionRow {
     }
 
     _onActivated(widget) {
-        let ctl = new Gtk.EventControllerKey();
+        const ctl = new Gtk.EventControllerKey();
 
-        let content = new Adw.StatusPage({
+        const content = new Adw.StatusPage({
             title: _('New accelerator…'),
             description: this._description,
             icon_name: 'preferences-desktop-keyboard-shortcuts-symbolic'

--- a/caffeine@patapon.info/preferences/timerPage.js
+++ b/caffeine@patapon.info/preferences/timerPage.js
@@ -47,7 +47,7 @@ class CaffeineTimerPage extends Adw.PreferencesPage {
 
         // Timer group
         // --------------
-        let timerGroup = new Adw.PreferencesGroup({
+        const timerGroup = new Adw.PreferencesGroup({
             title: _('Preset durations')
         });
 
@@ -58,7 +58,7 @@ class CaffeineTimerPage extends Adw.PreferencesPage {
             activatable: true
         });
 
-        let adjustSliderTimer = new Gtk.Adjustment({
+        const adjustSliderTimer = new Gtk.Adjustment({
             lower: 0,
             upper: 4,
             step_increment: 0.1,
@@ -94,7 +94,7 @@ class CaffeineTimerPage extends Adw.PreferencesPage {
             vexpand: false
         });
 
-        let customDurationGroup = new Adw.PreferencesGroup({
+        const customDurationGroup = new Adw.PreferencesGroup({
             title: _('Custom durations'),
             header_suffix: this.resetCustomTimerButton
         });
@@ -214,7 +214,7 @@ class CaffeineTimerPage extends Adw.PreferencesPage {
 
     _updateDurationVarian(value, index) {
         const variantDuration = this._settings.get_value(this._settingsKey.DURATION_TIMER_LIST);
-        let currentDurationValues = variantDuration.deepUnpack();
+        const currentDurationValues = variantDuration.deepUnpack();
         currentDurationValues[index] = value;
         const newVariant = new GLib.Variant('ai', currentDurationValues);
         this._settings.set_value(this._settingsKey.DURATION_TIMER_LIST, newVariant);
@@ -263,7 +263,7 @@ class CaffeineTimerPage extends Adw.PreferencesPage {
         */
 
         // Create the SpinRow
-        let spinRowAdjustment = new Gtk.Adjustment({
+        const spinRowAdjustment = new Gtk.Adjustment({
             lower: minValue,
             upper: maxValue,
             step_increment: step,
@@ -271,7 +271,7 @@ class CaffeineTimerPage extends Adw.PreferencesPage {
             value
         });
 
-        let spinRow = new Adw.SpinRow({
+        const spinRow = new Adw.SpinRow({
             title: name,
             climb_rate: 0,
             adjustment: spinRowAdjustment,
@@ -279,7 +279,7 @@ class CaffeineTimerPage extends Adw.PreferencesPage {
         });
 
         // Create new Entry
-        let timeEntry = new Gtk.Entry({
+        const timeEntry = new Gtk.Entry({
             editable: true,
             hexpand: true,
             halign: Gtk.Align.END,
@@ -291,10 +291,10 @@ class CaffeineTimerPage extends Adw.PreferencesPage {
         });
 
         // Get the Gtk.SpinButton and Gtk.Text
-        let childWidget = spinRow.get_last_child();
-        let boxWidget = childWidget.get_last_child();
-        let spinButtonWidget = boxWidget.get_first_child();
-        let spinButtonText = spinButtonWidget.get_first_child();
+        const childWidget = spinRow.get_last_child();
+        const boxWidget = childWidget.get_last_child();
+        const spinButtonWidget = boxWidget.get_first_child();
+        const spinButtonText = spinButtonWidget.get_first_child();
 
         // Hide the current text input
         spinButtonText.visible = false;

--- a/caffeine@patapon.info/prefs.js
+++ b/caffeine@patapon.info/prefs.js
@@ -55,7 +55,7 @@ const SettingsKey = {
 
 export default class CaffeinePrefs extends ExtensionPreferences {
     fillPreferencesWindow(window) {
-        let iconTheme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default());
+        const iconTheme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default());
         if (!iconTheme.get_search_path().includes(this.path + '/icons')) {
             iconTheme.add_search_path(this.path + '/icons');
         }
@@ -66,8 +66,8 @@ export default class CaffeinePrefs extends ExtensionPreferences {
         const timerPage = new TimerPrefs.TimerPage(settings, SettingsKey);
         const appsPage = new AppsPrefs.AppsPage(settings, SettingsKey);
 
-        let prefsWidth = settings.get_int(SettingsKey.DEFAULT_WIDTH);
-        let prefsHeight = settings.get_int(SettingsKey.DEFAULT_HEIGHT);
+        const prefsWidth = settings.get_int(SettingsKey.DEFAULT_WIDTH);
+        const prefsHeight = settings.get_int(SettingsKey.DEFAULT_HEIGHT);
 
         window.set_default_size(prefsWidth, prefsHeight);
         window.set_search_enabled(true);
@@ -78,8 +78,8 @@ export default class CaffeinePrefs extends ExtensionPreferences {
         window.add(appsPage);
 
         window.connect('close-request', () => {
-            let currentWidth = window.default_width;
-            let currentHeight = window.default_height;
+            const currentWidth = window.default_width;
+            const currentHeight = window.default_height;
             // Remember user window size adjustments.
             if (currentWidth !== prefsWidth || currentHeight !== prefsHeight) {
                 settings.set_int(SettingsKey.DEFAULT_WIDTH, currentWidth);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -164,6 +164,7 @@ module.exports = defineConfig([
             'operator-linebreak': ["error"],
             'padded-blocks': ["error", "never"],
             'prefer-arrow-callback': ["error"],
+            'prefer-const': ["error"],
             'prefer-destructuring': ["error"],
             'prefer-numeric-literals': ["error"],
             'prefer-promise-reject-errors': ["error"],


### PR DESCRIPTION
Enable `prefer-const` to use `const` instead of `var` or `let` where possible, then apply `make lint-fix`.