### PR TITLE
Correct inverted scroll direction for natural scrolling

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -912,7 +912,22 @@ class Caffeine extends QuickSettings.SystemIndicator {
     }
 
     _handleScrollEvent(event) {
-        switch (event.get_scroll_direction()) {
+        // Undo natural scrolling inversions (available on GNOME 49+)
+        let scrollDirection = event.get_scroll_direction();
+        if (ShellVersion >= 49) {
+            if (event.get_scroll_flags() & Clutter.ScrollFlags.INVERTED) {
+                switch (scrollDirection) {
+                case Clutter.ScrollDirection.UP:
+                    scrollDirection = Clutter.ScrollDirection.DOWN;
+                    break;
+                case Clutter.ScrollDirection.DOWN:
+                    scrollDirection = Clutter.ScrollDirection.UP;
+                    break;
+                }
+            }
+        }
+
+        switch (scrollDirection) {
         case Clutter.ScrollDirection.UP:
             if (!this._state) {
                 // User state on - UP


### PR DESCRIPTION
Brings this inline with upstream widgets: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3831

Unfortunately the information to do this is only available on GNOME 49, but it's better than nothing. Tested on GNOME OS Nightly post-49 and GNOME 48 on Debian.

Closes #378