### PR TITLE
Fix "Inhibit by undefined" in inhibitor list

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -397,7 +397,7 @@ const InhibitorManager = GObject.registerClass({
         const params = [
             GLib.Variant.new_string('caffeine-gnome-extension'),
             GLib.Variant.new_uint32(0),
-            GLib.Variant.new_string('Inhibit by %s'.format(this._name)),
+            GLib.Variant.new_string('Inhibited by Caffeine GNOME extension'),
             GLib.Variant.new_uint32(inhibitFlags)
         ];
         const paramsVariant = GLib.Variant.new_tuple(params);
@@ -637,7 +637,6 @@ class Caffeine extends QuickSettings.SystemIndicator {
         this._appSystem = Shell.AppSystem.get_default();
         this._indicator = this._addIndicator();
         this._settings = Me._settings;
-        this._name = Me.metadata.name;
         this._state = false;
 
         // Add indicator label for the timer


### PR DESCRIPTION
Found while testing GNOME 50, `this._name` was never passed in. Replace it with a more helpful string, and fix the bug at the same time.

Previously, `gnome-session-inhibit --list` would give `caffeine-gnome-extension: Inhibit by undefined (idle)`

Now we get `caffeine-gnome-extension: Inhibit by Caffeine GNOME extension (idle)`

The workflow failures are unrelated, I'll look into those (EDIT: sorted)