### PR TITLE
Update upload-artifact to v7

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -23,10 +23,11 @@ jobs:
       run: |
         make install
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: caffeine@patapon.info.zip
         path: caffeine@patapon.info.zip
+        archive: false
 
     - name: Test build area clean
       run: |


### PR DESCRIPTION
Update the action to v7, no changes strictly necessary

However, they did introduce an `archive` setting, which we can set to `false` if we're using a single file. Since our file is already compressed, there's no point compressing it twice, so we can disable that now :)