### PR TITLE
Add option to prevent sleep when the laptop lid is closed

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -57,6 +57,7 @@ const INDICATOR_POSITION = 'indicator-position';
 const INDICATOR_INDEX = 'indicator-position-index';
 const INDICATOR_POS_MAX = 'indicator-position-max';
 const CLI_TOGGLE_KEY = 'cli-toggle';
+const INHIBIT_LID_KEY = 'inhibit-lid';
 
 const ColorInterface = '<node> \
   <interface name="org.gnome.SettingsDaemon.Color"> \
@@ -81,7 +82,20 @@ const DBusSessionManagerIface = '<node>\
   </interface>\
 </node>';
 
+const LogindInterface = '<node>\
+  <interface name="org.freedesktop.login1.Manager">\
+    <method name="Inhibit">\
+        <arg type="s" direction="in" />\
+        <arg type="s" direction="in" />\
+        <arg type="s" direction="in" />\
+        <arg type="s" direction="in" />\
+        <arg type="h" direction="out" />\
+    </method>\
+  </interface>\
+</node>';
+
 const DBusSessionManagerProxy = Gio.DBusProxy.makeProxyWrapper(DBusSessionManagerIface);
+const LogindProxy = Gio.DBusProxy.makeProxyWrapper(LogindInterface);
 
 const ActionsPath = '/icons/hicolor/scalable/actions/';
 const DisabledIcon = 'my-caffeine-off-symbolic';
@@ -122,6 +136,7 @@ const InhibitorManager = GObject.registerClass({
 
         this._isInhibited = false;
         this._inhibitorCookie = null;
+        this._logindInhibitorFd = null;
         this._userEnabled = false;
         this._triggerApp = null;
         this._tempManageLight = false;
@@ -138,6 +153,15 @@ const InhibitorManager = GObject.registerClass({
         this._sessionManager = new DBusSessionManagerProxy(Gio.DBus.session,
             'org.gnome.SessionManager',
             '/org/gnome/SessionManager');
+        this._logindProxy = new LogindProxy(Gio.DBus.system,
+            'org.freedesktop.login1',
+            '/org/freedesktop/login1',
+            (proxy, error) => {
+                if (error) {
+                    log(error.message);
+                }
+            }
+        );
         this._colorProxy = new ColorProxy(
             Gio.DBus.session,
             'org.gnome.SettingsDaemon.Color',
@@ -164,6 +188,8 @@ const InhibitorManager = GObject.registerClass({
             () => this._updateState(),
             `changed::${INHIBIT_APPS_KEY}`,
             () => this._updateState(),
+            `changed::${INHIBIT_LID_KEY}`,
+            () => this._forceUpdate(),
             `changed::${TRIGGER_APPS_MODE}`,
             () => {
                 this._disconnectTriggerSignals();
@@ -411,6 +437,31 @@ const InhibitorManager = GObject.registerClass({
         } else {
             log('Failed to add inhibitor');
         }
+
+        // Add systemd-logind inhibitor to prevent lid-close sleep directly
+        if (this._settings.get_boolean(INHIBIT_LID_KEY)) {
+            try {
+                const logindParams = [
+                    GLib.Variant.new_string('handle-lid-switch'),
+                    GLib.Variant.new_string('caffeine-gnome-extension'),
+                    GLib.Variant.new_string('Inhibited by Caffeine GNOME extension'),
+                    GLib.Variant.new_string('block')
+                ];
+                const logindParamsVariant = GLib.Variant.new_tuple(logindParams);
+
+                const [, fdList] = this._logindProxy.call_with_unix_fd_list_sync(
+                    'Inhibit', logindParamsVariant,
+                    Gio.DBusCallFlags.NONE, -1, null, null);
+                if (fdList && fdList.get_length() > 0) {
+                    const fds = fdList.steal_fds();
+                    if (fds.length > 0) {
+                        this._logindInhibitorFd = fds[0];
+                    }
+                }
+            } catch (e) {
+                log(`Caffeine: Failed to call logind inhibitor: ${e.message}`);
+            }
+        }
     }
 
     _removeInhibitor() {
@@ -420,6 +471,17 @@ const InhibitorManager = GObject.registerClass({
             this._sessionManager.UninhibitRemote(this._inhibitorCookie);
             this._inhibitorCookie = null;
             this._isInhibited = false;
+        }
+
+        // Remove logind inhibitor by closing the file descriptor
+        if (this._logindInhibitorFd !== null) {
+            try {
+                // In GJS, closing the raw FD is done via GLib
+                GLib.close(this._logindInhibitorFd);
+                this._logindInhibitorFd = null;
+            } catch (e) {
+                log(`Caffeine: Failed to remove systemd-logind inhibitor: ${e.message}`);
+            }
         }
     }
 

--- a/caffeine@patapon.info/preferences/generalPage.js
+++ b/caffeine@patapon.info/preferences/generalPage.js
@@ -91,12 +91,20 @@ class CaffeineGeneralPage extends Adw.PreferencesPage {
             selected: this._settings.get_enum(this._settingsKey.SCREEN_BLANK)
         });
 
+        // Inhibit lid
+        const inhibitLidRow = new Adw.SwitchRow({
+            title: _('Inhibit sleep on lid close'),
+            subtitle: _('Prevent the laptop from going to sleep when the lid is closed'),
+            active: this._settings.get_boolean(this._settingsKey.INHIBIT_LID)
+        });
+
         // Add elements
         behaviorGroup.add(disableFullscreenRow);
         behaviorGroup.add(enableMprisRow);
         behaviorGroup.add(rememberStateRow);
         behaviorGroup.add(pauseNightLightRow);
         behaviorGroup.add(allowBlankScreenRow);
+        behaviorGroup.add(inhibitLidRow);
         this.add(behaviorGroup);
 
         // Shortcut group
@@ -147,6 +155,9 @@ class CaffeineGeneralPage extends Adw.PreferencesPage {
         });
         allowBlankScreenRow.connect('notify::selected', (widget) => {
             this._settings.set_enum(this._settingsKey.SCREEN_BLANK, widget.selected);
+        });
+        inhibitLidRow.connect('notify::active', (widget) => {
+            this._settings.set_boolean(this._settingsKey.INHIBIT_LID, widget.get_active());
         });
         deleteShortcutButton.connect('clicked', this._resetShortcut.bind(this));
         this._settings.connect(`changed::${this._settingsKey.TOGGLE_SHORTCUT}`, () => {

--- a/caffeine@patapon.info/prefs.js
+++ b/caffeine@patapon.info/prefs.js
@@ -50,7 +50,8 @@ const SettingsKey = {
     TRIGGER_APPS_MODE: 'trigger-apps-mode',
     INDICATOR_POSITION: 'indicator-position',
     INDICATOR_INDEX: 'indicator-position-index',
-    INDICATOR_POS_MAX: 'indicator-position-max'
+    INDICATOR_POS_MAX: 'indicator-position-max',
+    INHIBIT_LID: 'inhibit-lid'
 };
 
 export default class CaffeinePrefs extends ExtensionPreferences {

--- a/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
+++ b/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
@@ -126,5 +126,10 @@
       <default>false</default>
       <summary>Command line key to toggle state</summary>
     </key>
+    <key type="b" name="inhibit-lid">
+      <default>false</default>
+      <summary>Inhibit sleep on lid close</summary>
+      <description>Prevent the laptop from going to sleep when the lid is closed</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
## Summary

This PR adds a new setting that allows Caffeine to prevent the laptop from going to sleep when you close the lid.
## How it works

- A new toggle, "Inhibit sleep on lid close", has been added to the General settings tab. It is disabled by default.
- When enabled, the extension now communicates directly with systemd-logind (the system service that handles power buttons and lid sensors). It requests a "block" on the lid-switch handler as long as Caffeine is active.

## Changes

1. Schema: Added inhibit-lid boolean key.
2. Preferences: Added a switch row in the General settings page.
3. Core Logic: Added a D-Bus proxy for org.freedesktop.login1 to manage the system-level inhibitor lock using Unix file descriptors.