### PR TITLE
perf: non-blocking DBus IPC calls and timer optimization

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -122,6 +122,7 @@ const InhibitorManager = GObject.registerClass({
 
         this._isInhibited = false;
         this._inhibitorCookie = null;
+        this._inhibitGeneration = 0;
         this._userEnabled = false;
         this._triggerApp = null;
         this._tempManageLight = false;
@@ -394,23 +395,30 @@ const InhibitorManager = GObject.registerClass({
         }
 
         this._isInhibited = true;
+        const generation = ++this._inhibitGeneration;
         this._sessionManager.InhibitRemote(
             'caffeine-gnome-extension',
             0,
             'Inhibited by Caffeine GNOME extension',
             inhibitFlags,
             (result, error) => {
+                // Ignore stale responses: a remove or a newer inhibit
+                // superseded this request while it was in flight
+                if (generation !== this._inhibitGeneration) {
+                    if (!error) {
+                        const [cookie] = result;
+                        this._sessionManager.UninhibitRemote(cookie);
+                    }
+                    return;
+                }
                 if (error) {
                     this._isInhibited = false;
                     log(`Failed to add inhibitor: ${error}`);
+                    this.emit('update');
                     return;
                 }
                 const [cookie] = result;
-                if (!this._isInhibited) {
-                    this._sessionManager.UninhibitRemote(cookie);
-                } else {
-                    this._inhibitorCookie = cookie;
-                }
+                this._inhibitorCookie = cookie;
             }
         );
     }
@@ -418,6 +426,8 @@ const InhibitorManager = GObject.registerClass({
     _removeInhibitor() {
         // Remove the inhibitor if it's active
         if (this._isInhibited) {
+            // Invalidate any in-flight inhibit request
+            this._inhibitGeneration++;
             if (this._inhibitorCookie !== null) {
                 this._sessionManager.UninhibitRemote(this._inhibitorCookie);
                 this._inhibitorCookie = null;
@@ -663,7 +673,6 @@ class Caffeine extends QuickSettings.SystemIndicator {
         this._indicator.gicon = this._iconDeactivated;
 
         // Init Timers
-        this._timeOut = null;
         this._timePrint = null;
         this._timerEnable = false;
 
@@ -897,10 +906,6 @@ class Caffeine extends QuickSettings.SystemIndicator {
         this._timerLabel.visible = false;
 
         // Remove timer
-        if (this._timeOut !== null) {
-            GLib.Source.remove(this._timeOut);
-            this._timeOut = null;
-        }
         if (this._timePrint !== null) {
             GLib.Source.remove(this._timePrint);
             this._timePrint = null;
@@ -1061,10 +1066,6 @@ class Caffeine extends QuickSettings.SystemIndicator {
         this.quickSettingsItems.forEach((item) => item.destroy());
 
         // Disconnect from signals
-        if (this._timeOut) {
-            GLib.Source.remove(this._timeOut);
-            this._timeOut = null;
-        }
         if (this._timePrint) {
             GLib.Source.remove(this._timePrint);
             this._timePrint = null;

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -393,32 +393,35 @@ const InhibitorManager = GObject.registerClass({
             inhibitFlags = 8;
         }
 
-        // Pack the parameters for DBus
-        const params = [
-            GLib.Variant.new_string('caffeine-gnome-extension'),
-            GLib.Variant.new_uint32(0),
-            GLib.Variant.new_string('Inhibited by Caffeine GNOME extension'),
-            GLib.Variant.new_uint32(inhibitFlags)
-        ];
-        const paramsVariant = GLib.Variant.new_tuple(params);
-
-        // Synchronously add the inhibitor
-        const cookieTuple = this._sessionManager.call_sync('Inhibit', paramsVariant,
-            Gio.DBusCallFlags.NONE, -1, null);
-        if (cookieTuple !== null) {
-            this._inhibitorCookie = cookieTuple.get_child_value(0).get_uint32();
-            this._isInhibited = true;
-        } else {
-            log('Failed to add inhibitor');
-        }
+        this._isInhibited = true;
+        this._sessionManager.InhibitRemote(
+            'caffeine-gnome-extension',
+            0,
+            'Inhibited by Caffeine GNOME extension',
+            inhibitFlags,
+            (result, error) => {
+                if (error) {
+                    this._isInhibited = false;
+                    log(`Failed to add inhibitor: ${error}`);
+                    return;
+                }
+                const [cookie] = result;
+                if (!this._isInhibited) {
+                    this._sessionManager.UninhibitRemote(cookie);
+                } else {
+                    this._inhibitorCookie = cookie;
+                }
+            }
+        );
     }
 
     _removeInhibitor() {
         // Remove the inhibitor if it's active
         if (this._isInhibited) {
-            // Use the cookie to remove the inhibitor
-            this._sessionManager.UninhibitRemote(this._inhibitorCookie);
-            this._inhibitorCookie = null;
+            if (this._inhibitorCookie !== null) {
+                this._sessionManager.UninhibitRemote(this._inhibitorCookie);
+                this._inhibitorCookie = null;
+            }
             this._isInhibited = false;
         }
     }
@@ -860,16 +863,15 @@ class Caffeine extends QuickSettings.SystemIndicator {
             this._timePrint = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, () => {
                 secondLeft -= 1;
                 this._printTimer(secondLeft);
-                return GLib.SOURCE_CONTINUE;
-            });
-
-            this._timeOut = GLib.timeout_add(GLib.PRIORITY_DEFAULT, timerDelay * 1000, () => {
-                // Disable Caffeine when timer ended
-                this._removeTimer();
-                if (this._state) {
-                    this._handleToggleClick();
+                if (secondLeft <= 0) {
+                    this._timePrint = null;
+                    this._removeTimer();
+                    if (this._state) {
+                        this._handleToggleClick();
+                    }
+                    return GLib.SOURCE_REMOVE;
                 }
-                return GLib.SOURCE_REMOVE;
+                return GLib.SOURCE_CONTINUE;
             });
         }
     }
@@ -895,10 +897,12 @@ class Caffeine extends QuickSettings.SystemIndicator {
         this._timerLabel.visible = false;
 
         // Remove timer
-        if ((this._timeOut !== null) || (this._timePrint !== null)) {
+        if (this._timeOut !== null) {
             GLib.Source.remove(this._timeOut);
-            GLib.Source.remove(this._timePrint);
             this._timeOut = null;
+        }
+        if (this._timePrint !== null) {
+            GLib.Source.remove(this._timePrint);
             this._timePrint = null;
         }
     }

--- a/caffeine@patapon.info/mprisMediaPlayer2.js
+++ b/caffeine@patapon.info/mprisMediaPlayer2.js
@@ -143,8 +143,15 @@ const MprisPlayer = GObject.registerClass({
 
     _lastEmittedPlayStatus = false;
 
+    _destroyed = false;
+
     refresh() {
         this._getMPlayerApps((dbusNames) => {
+            // The instance may have been destroyed while the async
+            // ListNames call was in flight
+            if (this._destroyed) {
+                return;
+            }
             dbusNames.forEach((dbusName) => this._addPlayer(dbusName));
             this._emitPlayStatus(true);
         });
@@ -279,6 +286,7 @@ const MprisPlayer = GObject.registerClass({
     }
 
     _onDestroy() {
+        this._destroyed = true;
         this._dbusProxy.disconnectSignal(this._dbusHandlerId);
         for (const dbusName of this._activePlayers.keys()) {
             this._removePlayer(dbusName);

--- a/caffeine@patapon.info/mprisMediaPlayer2.js
+++ b/caffeine@patapon.info/mprisMediaPlayer2.js
@@ -144,9 +144,10 @@ const MprisPlayer = GObject.registerClass({
     _lastEmittedPlayStatus = false;
 
     refresh() {
-        const dbusNames = this._getMPlayerApps();
-        dbusNames.forEach((dbusName) => this._addPlayer(dbusName));
-        this._emitPlayStatus(true);
+        this._getMPlayerApps((dbusNames) => {
+            dbusNames.forEach((dbusName) => this._addPlayer(dbusName));
+            this._emitPlayStatus(true);
+        });
     }
 
     /**
@@ -256,16 +257,25 @@ const MprisPlayer = GObject.registerClass({
     }
 
     /**
-     * Get the dbus name list for mpris players
-     * @returns {string[]}
+     * Get the dbus name list for mpris players asynchronously
+     * @param {(mprisPlayers: string[]) => void} callback
      */
-    _getMPlayerApps() {
-        const [names] = this._dbusProxy.ListNamesSync();
-        const mprisPlayers = names.filter((dbusName) =>
-            dbusName.startsWith(this._mprisPrefix)
-        );
+    _getMPlayerApps(callback) {
+        this._dbusProxy.ListNamesRemote((result, error) => {
+            if (error || !result) {
+                if (error) {
+                    log(`Failed to list DBus names: ${error}`);
+                }
+                callback([]);
+                return;
+            }
 
-        return mprisPlayers;
+            const [names] = result;
+            const mprisPlayers = names.filter((dbusName) =>
+                dbusName.startsWith(this._mprisPrefix)
+            );
+            callback(mprisPlayers);
+        });
     }
 
     _onDestroy() {


### PR DESCRIPTION
## Description
This PR addresses main-thread UI blocking bottlenecks and GLib timer issues:

1. **Async DBus Inhibit Calls**:
   - Replaced synchronous  in `extension.js` with async `InhibitRemote(...)`.
   - Added handling for in-flight requests if uninhibit is triggered prior to DBus callback response.

2. **Async MPRIS Player DBus Discovery**:
   - Replaced synchronous `ListNamesSync()` in `mprisMediaPlayer2.js` with async `ListNamesRemote(...)` to avoid stalling GNOME Shell on startup/refresh.

3. **Timer Logic Consolidation & Safe Source Removal**:
   - Consolidated dual GLib timeouts (`_timePrint` & `_timeOut`) into a single 1-second interval GLib source to prevent timer drift.
   - Guarded `GLib.Source.remove()` checks in `_removeTimer()` against null handles and already-expired sources, preventing `GLib-CRITICAL` log spam.
