### PR TITLE
feat(shell): Add support for GNOME Shell 51

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -705,8 +705,19 @@ class Caffeine extends QuickSettings.SystemIndicator {
 
         // Change user state on icon scroll event
         this._indicator.reactive = true;
-        this._indicator.connectObject('scroll-event',
-            (actor, event) => this._handleScrollEvent(event), this);
+        if (ShellVersion >= 51) {
+            const scrollController = new Clutter.ScrollController({
+                flags: Clutter.ScrollControllerFlags.DISCRETE |
+                    Clutter.ScrollControllerFlags.SCROLL_VERTICAL |
+                    Clutter.ScrollControllerFlags.PHYSICAL_DIRECTION
+            });
+            scrollController.connectObject(
+                'scroll', this._handleScrollController.bind(this), this);
+            this._indicator.add_action(scrollController);
+        } else {
+            this._indicator.connectObject('scroll-event',
+                (_actor, event) => this._handleScrollEvent(event), this);
+        }
 
         // Init position and index of indicator icon
         this.indicatorPosition = this._settings.get_int(INDICATOR_POSITION);
@@ -910,6 +921,14 @@ class Caffeine extends QuickSettings.SystemIndicator {
         this._caffeineToggle.subtitle = text;
     }
 
+    _handleScrollController(_controller, _sprite, _source, _dx, dy) {
+        if (dy < 0) {
+            this._handleScrollDirection(Clutter.ScrollDirection.UP);
+        } else if (dy > 0) {
+            this._handleScrollDirection(Clutter.ScrollDirection.DOWN);
+        }
+    }
+
     _handleScrollEvent(event) {
         // Undo natural scrolling inversions (available on GNOME 49+)
         let scrollDirection = event.get_scroll_direction();
@@ -926,6 +945,10 @@ class Caffeine extends QuickSettings.SystemIndicator {
             }
         }
 
+        this._handleScrollDirection(scrollDirection);
+    }
+
+    _handleScrollDirection(scrollDirection) {
         switch (scrollDirection) {
         case Clutter.ScrollDirection.UP:
             if (!this._state) {
@@ -1091,6 +1114,7 @@ export default class CaffeineExtension extends Extension {
     disable() {
         this._caffeineIndicator.destroy();
         this._caffeineIndicator = null;
+        this._settings = null;
 
         // Unregister shortcut
         Main.wm.removeKeybinding(TOGGLE_SHORTCUT);
@@ -1098,6 +1122,10 @@ export default class CaffeineExtension extends Extension {
 
     _openPreferences() {
         this.openPreferences();
-        QuickSettingsMenu.menu.close(PopupAnimation.FADE);
+        if (ShellVersion >= 51) {
+            QuickSettingsMenu.menu.close({ fadeOnly: true });
+        } else {
+            QuickSettingsMenu.menu.close(PopupAnimation.FADE);
+        }
     }
 }

--- a/caffeine@patapon.info/locale/pt_BR.po
+++ b/caffeine@patapon.info/locale/pt_BR.po
@@ -1,6 +1,6 @@
 # Brazilian Portuguese translation for GNOME Shell Extension Caffeine.
 # Copyright (C) 2020 Jean-Philippe Braun
-# This file is distributed under the same license as the gnome-shell-extesion-caffeine package.
+# This file is distributed under the same license as the gnome-shell-extension-caffeine package.
 # Rafael Fontenelle <rafaelff@gnome.org>, 2014-2020.
 #
 msgid ""

--- a/caffeine@patapon.info/metadata.json
+++ b/caffeine@patapon.info/metadata.json
@@ -1,7 +1,7 @@
 {
   "version": 60,
   "shell-version": [
-    "45", "46", "47", "48", "49", "50"
+    "45", "46", "47", "48", "49", "50", "51"
   ],
   "uuid": "caffeine@patapon.info",
   "name": "Caffeine",


### PR DESCRIPTION
 uses deprecated scroll-event; it remains functional in GNOME 51 but should eventually move to Clutter.ScrollController.